### PR TITLE
Add new Telebirr SMS Parsing

### DIFF
--- a/app/lib/services/sms_config_service.dart
+++ b/app/lib/services/sms_config_service.dart
@@ -506,6 +506,26 @@ class SmsConfigService {
       refRequired: true,
       hasAccount: false,
     ),
+    SmsPattern(
+      bankId: 6,
+      senderId: "telebirr",
+      regex:
+          r"You\s+have\s+paid\s+ETB\s+(?<amount>[\d,.]+)\s+for\s+(?<receiver>.+?)\s+with\s+payment\s+code\s+(?<reference>[A-Z0-9]+)\s+on\s+(?<date>\d{2}/\d{2}/\d{4}).*?balance\s+is\s+ETB\s+(?<balance>[\d,.]+)",
+      type: "DEBIT",
+      description: "Telebirr 127 Payment",
+      refRequired: true,
+      hasAccount: false,
+    ),
+    SmsPattern(
+      bankId: 6,
+      senderId: "telebirr",
+      regex:
+          r"You\s+have\s+recharged\s+ETB\s+(?<amount>[\d,.]+)\s+airtime\s+for\s+(?<receiver>[\d]+)\s+on\s+(?<date>\d{2}/\d{2}/\d{4}).*?transaction\s+number\s+is\s+(?<reference>[A-Z0-9]+).*?balance\s+is\s+ETB\s+(?<balance>[\d,.]+)",
+      type: "DEBIT",
+      description: "Telebirr Airtime Recharge",
+      refRequired: true,
+      hasAccount: false,
+    ),
   ];
   void debugSms(String smsText) {
     // Show invisible characters


### PR DESCRIPTION
added support for parsing two new types of SMS messages from Telebirr.
1. Payment messages from sender
![telegram-cloud-document-4-5951622824442468900](https://github.com/user-attachments/assets/5043f7f1-4bf0-45b1-a288-eee2eb3ca78e)

2. Airtime purchase messages by telebirr
![telegram-cloud-document-4-5951622824442468901](https://github.com/user-attachments/assets/897d7b68-6071-42b7-8737-02a724a1ba7d)
