### PR TITLE
refactor: drive redesign shell navigation with TabController

### DIFF
--- a/app/lib/_redesign/screens/redesign_shell.dart
+++ b/app/lib/_redesign/screens/redesign_shell.dart
@@ -50,7 +50,8 @@ class RedesignShell extends StatefulWidget {
 }
 
 class RedesignShellState extends State<RedesignShell>
-    with WidgetsBindingObserver {
+    with WidgetsBindingObserver, SingleTickerProviderStateMixin {
+  static const int _tabCount = 5;
   // Temporary kill switch for the automatic battery optimization prompt.
   // Users can still request the exemption manually from notification settings.
   static const bool _autoShowBatteryOptimizationPrompt = false;
@@ -62,8 +63,7 @@ class RedesignShellState extends State<RedesignShell>
       GlobalKey<RedesignMoneyPageState>();
   final GlobalKey<RedesignBudgetPageState> _budgetPageKey =
       GlobalKey<RedesignBudgetPageState>();
-  final PageController _pageController =
-      PageController(initialPage: _homeIndex);
+  late final TabController _tabController;
   DateTime? _lastProfileTabTapAt;
   int _currentIndex = _homeIndex;
   int? _activeProfileId;
@@ -88,6 +88,12 @@ class RedesignShellState extends State<RedesignShell>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    _tabController = TabController(
+      length: _tabCount,
+      vsync: this,
+      initialIndex: _homeIndex,
+    );
+    _tabController.addListener(_handleTabControllerChanged);
     BackgroundRefreshSignalService.instance.ensureListening();
     unawaited(BankDetectionStartupService.runOnAppOpen());
     unawaited(_loadActiveProfileId());
@@ -179,7 +185,8 @@ class RedesignShellState extends State<RedesignShell>
     _widgetLaunchIntentSub?.cancel();
     _notificationIntentSub?.cancel();
     _backgroundRefreshSub?.cancel();
-    _pageController.dispose();
+    _tabController.removeListener(_handleTabControllerChanged);
+    _tabController.dispose();
     super.dispose();
   }
 
@@ -398,7 +405,16 @@ class RedesignShellState extends State<RedesignShell>
     }
   }
 
+  void _handleTabControllerChanged() {
+    if (!mounted) return;
+    final index = _tabController.index;
+    if (_currentIndex != index) {
+      setState(() => _currentIndex = index);
+    }
+  }
+
   void lockApp() {
+    _tabController.index = _homeIndex;
     setState(() {
       _isAuthenticated = false;
       _currentIndex = _homeIndex;
@@ -455,7 +471,7 @@ class RedesignShellState extends State<RedesignShell>
     setState(() {
       _currentIndex = index;
     });
-    _pageController.animateToPage(
+    _tabController.animateTo(
       index,
       duration: const Duration(milliseconds: 250),
       curve: Curves.easeOutCubic,
@@ -721,15 +737,9 @@ class RedesignShellState extends State<RedesignShell>
         },
         child: Scaffold(
           extendBody: true,
-          body: PageView(
-            controller: _pageController,
+          body: TabBarView(
+            controller: _tabController,
             physics: const PageScrollPhysics(),
-            onPageChanged: (index) {
-              if (_currentIndex == index || !mounted) return;
-              setState(() {
-                _currentIndex = index;
-              });
-            },
             children: [
               const RedesignHomePage(),
               RedesignMoneyPage(key: _moneyPageKey),
@@ -742,7 +752,7 @@ class RedesignShellState extends State<RedesignShell>
           ),
           bottomNavigationBar: RedesignBottomNav(
             currentIndex: _currentIndex,
-            pageController: _pageController,
+            tabController: _tabController,
             onTap: _onTabSelected,
             onMoneyLongPress: _showQuickCashSheet,
             onToolsLongPress: _showQuickAccessAccountsSheet,

--- a/app/lib/_redesign/widgets/redesign_bottom_nav.dart
+++ b/app/lib/_redesign/widgets/redesign_bottom_nav.dart
@@ -8,7 +8,7 @@ class RedesignBottomNav extends StatelessWidget {
   static const int _tabCount = 5;
 
   final int currentIndex;
-  final PageController pageController;
+  final TabController tabController;
   final ValueChanged<int> onTap;
   final VoidCallback? onMoneyLongPress;
   final VoidCallback? onToolsLongPress;
@@ -17,7 +17,7 @@ class RedesignBottomNav extends StatelessWidget {
   const RedesignBottomNav({
     super.key,
     required this.currentIndex,
-    required this.pageController,
+    required this.tabController,
     required this.onTap,
     this.onMoneyLongPress,
     this.onToolsLongPress,
@@ -25,10 +25,11 @@ class RedesignBottomNav extends StatelessWidget {
   });
 
   double _resolvePage() {
-    if (!pageController.hasClients) return currentIndex.toDouble();
-    final page = pageController.page;
-    if (page == null || !page.isFinite) return currentIndex.toDouble();
-    return page.clamp(0.0, (_tabCount - 1).toDouble()).toDouble();
+    final animation = tabController.animation;
+    if (animation == null || !animation.value.isFinite) {
+      return currentIndex.toDouble();
+    }
+    return animation.value.clamp(0.0, (_tabCount - 1).toDouble()).toDouble();
   }
 
   double _selectionProgress(double page, int index) {
@@ -77,7 +78,7 @@ class RedesignBottomNav extends StatelessWidget {
     ];
 
     return AnimatedBuilder(
-      animation: pageController,
+      animation: tabController.animation ?? tabController,
       builder: (context, child) {
         final page = _resolvePage();
 


### PR DESCRIPTION
Replace the PageView/PageController in RedesignShell with a TabBarView driven by a TabController, and update RedesignBottomNav to slide its indicator from the controller's animation. Preserves swipe navigation, tap-to-switch, the animated indicator, and double-tap-to-lock behavior.