### PR TITLE
feat: enriched SMS parser with fieldMapping, amount derivation, totalFee

### DIFF
--- a/app/lib/database/database_helper.dart
+++ b/app/lib/database/database_helper.dart
@@ -23,7 +23,7 @@ class DatabaseHelper {
 
     final db = await openDatabase(
       path,
-      version: 27,
+      version: 28,
       onCreate: _createDB,
       onUpgrade: _upgradeDB,
     );
@@ -100,7 +100,8 @@ class DatabaseHelper {
         profileId INTEGER,
         sourceType TEXT,
         sourceMessageId TEXT,
-        sourceFingerprint TEXT
+        sourceFingerprint TEXT,
+        totalFee REAL
       )
     ''');
 
@@ -125,7 +126,9 @@ class DatabaseHelper {
         type TEXT NOT NULL,
         description TEXT,
         refRequired INTEGER,
-        hasAccount INTEGER
+        hasAccount INTEGER,
+        hasFees INTEGER,
+        mapping TEXT
       )
     ''');
 
@@ -822,6 +825,23 @@ class DatabaseHelper {
     if (oldVersion < 27) {
       await _ensureTransactionSourceSchema(db);
       await _ensureSyncSchema(db);
+    }
+
+    if (oldVersion < 28) {
+      try {
+        await db.execute(
+          'ALTER TABLE sms_patterns ADD COLUMN hasFees INTEGER',
+        );
+        await db.execute(
+          'ALTER TABLE sms_patterns ADD COLUMN mapping TEXT',
+        );
+        await db.execute(
+          'ALTER TABLE transactions ADD COLUMN totalFee REAL',
+        );
+        print("debug: Added hasFees/mapping columns to sms_patterns and totalFee to transactions");
+      } catch (e) {
+        print("debug: Error adding v28 columns (might already exist): $e");
+      }
     }
   }
 

--- a/app/lib/models/sms_pattern.dart
+++ b/app/lib/models/sms_pattern.dart
@@ -7,6 +7,8 @@ class SmsPattern {
       description; // For debugging, e.g., "CBE Debit with Service Charge"
   final bool? refRequired;
   final bool? hasAccount;
+  final bool? hasFees;
+  final Map<String, String>? fieldMapping;
 
   SmsPattern({
     required this.bankId,
@@ -16,6 +18,8 @@ class SmsPattern {
     this.description = "",
     this.refRequired,
     this.hasAccount,
+    this.hasFees,
+    this.fieldMapping,
   });
 
   factory SmsPattern.fromJson(Map<String, dynamic> json) {
@@ -27,6 +31,10 @@ class SmsPattern {
       description: json['description'] ?? "",
       refRequired: json['refRequired'],
       hasAccount: json['hasAccount'],
+      hasFees: json['hasFees'],
+      fieldMapping: json['fieldMapping'] != null
+          ? Map<String, String>.from(json['fieldMapping'])
+          : null,
     );
   }
 
@@ -39,6 +47,8 @@ class SmsPattern {
       'description': description,
       'refRequired': refRequired,
       'hasAccount': hasAccount,
+      'hasFees': hasFees,
+      'fieldMapping': fieldMapping,
     };
   }
 }

--- a/app/lib/models/transaction.dart
+++ b/app/lib/models/transaction.dart
@@ -18,6 +18,7 @@ class Transaction {
   final int? profileId;
   final double? serviceCharge;
   final double? vat;
+  final double? totalFee;
   final String? sourceType;
   final String? sourceMessageId;
   final String? sourceFingerprint;
@@ -40,6 +41,7 @@ class Transaction {
     this.profileId,
     this.serviceCharge,
     this.vat,
+    this.totalFee,
     this.sourceType,
     this.sourceMessageId,
     this.sourceFingerprint,
@@ -159,6 +161,7 @@ class Transaction {
       profileId: toInt(json['profileId']),
       serviceCharge: toDouble(json['serviceCharge']),
       vat: toDouble(json['vat']),
+      totalFee: toDouble(json['totalFee']),
       sourceType: json['sourceType']?.toString(),
       sourceMessageId: json['sourceMessageId']?.toString(),
       sourceFingerprint: json['sourceFingerprint']?.toString(),
@@ -183,6 +186,7 @@ class Transaction {
         if (profileId != null) 'profileId': profileId,
         if (serviceCharge != null) 'serviceCharge': serviceCharge,
         if (vat != null) 'vat': vat,
+        if (totalFee != null) 'totalFee': totalFee,
         if (sourceType != null) 'sourceType': sourceType,
         if (sourceMessageId != null) 'sourceMessageId': sourceMessageId,
         if (sourceFingerprint != null) 'sourceFingerprint': sourceFingerprint,
@@ -206,6 +210,7 @@ class Transaction {
     int? profileId,
     double? serviceCharge,
     double? vat,
+    double? totalFee,
     String? sourceType,
     String? sourceMessageId,
     String? sourceFingerprint,
@@ -263,6 +268,7 @@ class Transaction {
       profileId: profileId ?? this.profileId,
       serviceCharge: serviceCharge ?? this.serviceCharge,
       vat: vat ?? this.vat,
+      totalFee: totalFee ?? this.totalFee,
       sourceType: sourceType ?? this.sourceType,
       sourceMessageId: sourceMessageId ?? this.sourceMessageId,
       sourceFingerprint: sourceFingerprint ?? this.sourceFingerprint,

--- a/app/lib/repositories/transaction_repository.dart
+++ b/app/lib/repositories/transaction_repository.dart
@@ -92,6 +92,7 @@ class TransactionRepository {
       'sourceType': map['sourceType'],
       'sourceMessageId': map['sourceMessageId'],
       'sourceFingerprint': map['sourceFingerprint'],
+      'totalFee': map['totalFee'],
     });
   }
 
@@ -164,6 +165,7 @@ class TransactionRepository {
       'sourceType': transactionToSave.sourceType,
       'sourceMessageId': transactionToSave.sourceMessageId,
       'sourceFingerprint': transactionToSave.sourceFingerprint,
+      'totalFee': transactionToSave.totalFee,
       'year': year,
       'month': month,
       'day': day,
@@ -261,6 +263,7 @@ class TransactionRepository {
           'sourceType': transactionToSave.sourceType,
           'sourceMessageId': transactionToSave.sourceMessageId,
           'sourceFingerprint': transactionToSave.sourceFingerprint,
+          'totalFee': transactionToSave.totalFee,
           'year': year,
           'month': month,
           'day': day,

--- a/app/lib/services/enrichment_pipeline.dart
+++ b/app/lib/services/enrichment_pipeline.dart
@@ -1,0 +1,38 @@
+import 'package:totals/models/transaction.dart';
+
+/// Transforms a parsed [Transaction] after extraction.
+///
+/// Enrichers run in registration order. Each receives the raw SMS body
+/// alongside the transaction so it can re-scan the original text if needed.
+/// New enrichers are added by calling [EnrichmentPipeline.add] — no changes
+/// to the extractor or orchestrator are required.
+abstract class TransactionEnricher {
+  Future<Transaction> enrich(Transaction transaction, String rawMessage);
+}
+
+/// Chains multiple [TransactionEnricher]s into a single pass.
+///
+/// Usage:
+///   final pipeline = EnrichmentPipeline()
+///     ..add(MerchantNormalizer())
+///     ..add(CategorizerEnricher());
+///   final enriched = await pipeline.enrich(tx, rawSms);
+class EnrichmentPipeline {
+  final List<TransactionEnricher> _enrichers = [];
+
+  void add(TransactionEnricher enricher) {
+    _enrichers.add(enricher);
+  }
+
+  void remove(TransactionEnricher enricher) {
+    _enrichers.remove(enricher);
+  }
+
+  Future<Transaction> enrich(Transaction transaction, String rawMessage) async {
+    var tx = transaction;
+    for (final enricher in _enrichers) {
+      tx = await enricher.enrich(tx, rawMessage);
+    }
+    return tx;
+  }
+}

--- a/app/lib/services/sms_config_service.dart
+++ b/app/lib/services/sms_config_service.dart
@@ -67,6 +67,11 @@ class SmsConfigService {
                 map['refRequired'] == null ? null : (map['refRequired'] == 1),
             'hasAccount':
                 map['hasAccount'] == null ? null : (map['hasAccount'] == 1),
+            'hasFees':
+                map['hasFees'] == null ? null : (map['hasFees'] == 1),
+            'fieldMapping': map['mapping'] != null
+                ? Map<String, String>.from(jsonDecode(map['mapping']))
+                : null,
           });
         }).toList();
         print("debug: Loaded ${patterns.length} patterns from database");
@@ -198,6 +203,9 @@ class SmsConfigService {
             pattern.refRequired == null ? null : (pattern.refRequired! ? 1 : 0),
         'hasAccount':
             pattern.hasAccount == null ? null : (pattern.hasAccount! ? 1 : 0),
+        'hasFees':
+            pattern.hasFees == null ? null : (pattern.hasFees! ? 1 : 0),
+        'mapping': pattern.fieldMapping != null ? jsonEncode(pattern.fieldMapping) : null,
       });
     }
     await batch.commit(noResult: true);

--- a/app/lib/services/sms_service.dart
+++ b/app/lib/services/sms_service.dart
@@ -6,6 +6,9 @@ import 'package:flutter/foundation.dart';
 import 'package:totals/models/bank.dart';
 import 'package:totals/services/sms_config_service.dart';
 import 'package:totals/services/bank_config_service.dart';
+import 'package:totals/services/categorizer_enricher.dart';
+import 'package:totals/services/enrichment_pipeline.dart';
+import 'package:totals/services/merchant_normalizer.dart';
 import 'package:totals/utils/pattern_parser.dart';
 import 'package:totals/repositories/transaction_repository.dart';
 import 'package:totals/repositories/account_repository.dart';
@@ -135,6 +138,22 @@ class SmsService {
   static const Duration _canonicalInboxLookupFutureSlack =
       Duration(seconds: 15);
 
+  // Pipeline of post-extraction enrichers.
+  static final EnrichmentPipeline enrichmentPipeline = EnrichmentPipeline();
+
+  static bool _enrichersRegistered = false;
+
+  static void _registerEnrichers() {
+    if (_enrichersRegistered) return;
+    _enrichersRegistered = true;
+    enrichmentPipeline.add(MerchantNormalizer());
+    enrichmentPipeline.add(CategorizerEnricher());
+  }
+
+  static void addEnricher(TransactionEnricher enricher) {
+    enrichmentPipeline.add(enricher);
+  }
+
   // Callback for foreground-only UI updates.
   ValueChanged<Transaction>? onTransactionSaved;
 
@@ -146,6 +165,7 @@ class SmsService {
   }
 
   Future<void> init() async {
+    _registerEnrichers();
     final bool? result = await _telephony.requestSmsPermissions;
     if (result != null && result) {
       _registerIncomingSmsListener();
@@ -1250,9 +1270,8 @@ class SmsService {
     }
 
     // 5. Save Transaction
-    // Need to ensure details has all fields or handle parsing
-    // Transaction.fromJson expects Strings mostly?
     Transaction newTx = Transaction.fromJson(details);
+    newTx = await enrichmentPipeline.enrich(newTx, messageBody);
     await txRepo.saveTransaction(
       newTx,
       skipAutoCategorization: skipAutoCategorization,

--- a/app/lib/utils/account_balance_resolver.dart
+++ b/app/lib/utils/account_balance_resolver.dart
@@ -16,8 +16,6 @@ double resolveDisplayedAccountBalance({
     return account.balance + cashBalanceDelta;
   }
 
-  // For banks with a single linked account, the latest SMS "balance after"
-  // is the most reliable remaining balance to show in the UI.
   if (bankAccountCount == 1) {
     final latestBalanceAfter = latestParsedBalanceAfter(accountTransactions);
     if (latestBalanceAfter != null) {
@@ -29,38 +27,35 @@ double resolveDisplayedAccountBalance({
 }
 
 double? latestParsedBalanceAfter(Iterable<Transaction> transactions) {
-  double? latestBalance;
-  DateTime? latestTime;
+  final sorted = List<Transaction>.from(transactions)
+    ..sort((a, b) {
+      final timeA = _parseTransactionTime(a.time);
+      final timeB = _parseTransactionTime(b.time);
+      if (timeA == null && timeB == null) return 0;
+      if (timeA == null) return -1;
+      if (timeB == null) return 1;
+      return timeA.compareTo(timeB);
+    });
 
-  for (final transaction in transactions) {
+  double? runningBalance;
+
+  for (final transaction in sorted) {
     final parsedBalance = _parseBalance(transaction.currentBalance);
-    if (parsedBalance == null) continue;
-
-    final transactionTime = _parseTransactionTime(transaction.time);
-    if (latestBalance == null) {
-      latestBalance = parsedBalance;
-      latestTime = transactionTime;
-      continue;
-    }
-
-    if (transactionTime == null && latestTime != null) {
-      continue;
-    }
-
-    if (transactionTime != null &&
-        (latestTime == null ||
-            !transactionTime.isBefore(latestTime))) {
-      latestBalance = parsedBalance;
-      latestTime = transactionTime;
-      continue;
-    }
-
-    if (transactionTime == null && latestTime == null) {
-      latestBalance = parsedBalance;
+    if (parsedBalance != null) {
+      runningBalance = parsedBalance;
+    } else if (runningBalance != null) {
+      final amount = transaction.amount;
+      final totalFee = transaction.totalFee ?? 0.0;
+      final total = amount + totalFee;
+      if (transaction.type == 'CREDIT') {
+        runningBalance = runningBalance! + total;
+      } else {
+        runningBalance = runningBalance! - total;
+      }
     }
   }
 
-  return latestBalance;
+  return runningBalance;
 }
 
 double? _parseBalance(String? raw) {

--- a/app/lib/utils/pattern_parser.dart
+++ b/app/lib/utils/pattern_parser.dart
@@ -27,30 +27,42 @@ class PatternParser {
           print("debug: ✓ Pattern Matched: ${pattern.description}");
           print("debug: Available named groups: ${match.groupNames.toList()}");
 
+          final mapping = pattern.fieldMapping;
           final Map<String, dynamic> extracted = {};
 
-          // Extract known named groups
-          // We support: amount, balance, account, reference, creditor, receiver,
-          // sender/source (for incoming transfers), time
-
           extracted['type'] = pattern.type;
-          extracted['bankId'] = pattern.bankId; // Default bank ID from pattern
+          extracted['bankId'] = pattern.bankId;
           extracted['patternDescription'] = pattern.description;
 
-          if (match.groupNames.contains('amount')) {
-            print("debug: Extracted amount: ${match.namedGroup('amount')}");
-            final cleanedAmount = _cleanNumber(match.namedGroup('amount'));
-            extracted['amount'] = double.tryParse(cleanedAmount ?? "");
-            print("debug: Extracted amount: ${extracted['amount']}");
+          String? typeOverride;
+          if (_hasGroup(match, mapping, 'type')) {
+            typeOverride = _normalizeType(_groupValue(match, mapping, 'type'));
           }
-          if (match.groupNames.contains('balance')) {
-            extracted['currentBalance'] =
-                _cleanNumber(match.namedGroup('balance'));
-            print("debug: Extracted balance: ${extracted['currentBalance']}");
+          final transactionType = typeOverride ?? pattern.type;
+
+          double? amount = _hasGroup(match, mapping, 'amount')
+              ? double.tryParse(
+                  _cleanNumber(_groupValue(match, mapping, 'amount')) ?? "")
+              : null;
+          if (amount != null) {
+            extracted['amount'] = amount;
           }
-          if (match.groupNames.contains('account')) {
+
+          String? currentBalance = _hasGroup(match, mapping, 'balance')
+              ? _cleanNumber(_groupValue(match, mapping, 'balance'))
+              : null;
+          if (currentBalance != null) {
+            extracted['currentBalance'] = currentBalance;
+          }
+
+          String? reference = _hasGroup(match, mapping, 'reference')
+              ? _groupValue(match, mapping, 'reference')
+              : null;
+
+          String? accountNumber;
+          if (_hasGroup(match, mapping, 'account')) {
             print("debug: ✓ after account - entering account extraction block");
-            String? raw = match.namedGroup('account');
+            String? raw = _groupValue(match, mapping, 'account');
             print("debug: Raw account value: '$raw'");
 
             if (raw != null) {
@@ -59,123 +71,128 @@ class PatternParser {
               final bank =
                   availableBanks.firstWhere((b) => b.id == pattern.bankId);
 
-              // Use bank configuration for account extraction
               if (bank.uniformMasking == true && bank.maskPattern != null) {
-                // Extract last N digits based on mask pattern
                 if (raw.length >= bank.maskPattern!) {
-                  extracted['accountNumber'] =
+                  accountNumber =
                       raw.substring(raw.length - bank.maskPattern!);
-                  print(
-                      "Cleaned account (masked): ${extracted['accountNumber']}");
+                  print("Cleaned account (masked): $accountNumber");
                 } else {
-                  extracted['accountNumber'] = raw;
-                  print(
-                      "Cleaned account (fallback): ${extracted['accountNumber']}");
+                  accountNumber = raw;
+                  print("Cleaned account (fallback): $accountNumber");
                 }
               } else {
-                // No masking or uniformMasking is false - use full account number
-                extracted['accountNumber'] = raw;
-                print(
-                    "Cleaned account (direct): ${extracted['accountNumber']}");
+                accountNumber = raw;
+                print("Cleaned account (direct): $accountNumber");
               }
             } else {
               print("debug: ✗ Raw account is null!");
+            }
+            if (accountNumber != null) {
+              extracted['accountNumber'] = accountNumber;
             }
           } else {
             print("debug: ✗ 'account' group NOT found in named groups");
           }
 
-          if (match.groupNames.contains('reference')) {
-            extracted['reference'] = match.namedGroup('reference');
-            print("debug: Extracted reference: ${extracted['reference']}");
-          }
-          if (match.groupNames.contains('type')) {
-            final rawType = match.namedGroup('type');
-            final normalized = _normalizeType(rawType);
-            if (normalized != null) {
-              extracted['type'] = normalized;
+          if (reference == null) {
+            if (pattern.refRequired == false) {
+              final fallbackDate = messageDate ?? DateTime.now();
+              final typePart = transactionType;
+              final amountPart = amount?.toStringAsFixed(2) ?? 'NA';
+              final accountPart = accountNumber ?? 'NA';
+              reference =
+                  "${pattern.bankId}_${typePart}_${amountPart}_${accountPart}_${fallbackDate.toIso8601String()}";
             }
           }
-          if (match.groupNames.contains('creditor')) {
-            extracted['creditor'] = match.namedGroup('creditor');
+          if (reference != null) {
+            extracted['reference'] = reference;
           }
-          if (match.groupNames.contains("receiver")) {
-            extracted['receiver'] = match.namedGroup('receiver');
+
+          String? creditor;
+          String? receiver;
+          if (_hasGroup(match, mapping, 'creditor')) {
+            creditor = _groupValue(match, mapping, 'creditor');
           }
-          _assignOptionalAmount(
-            extracted,
-            'serviceCharge',
-            match,
-            const [
-              'serviceCharge',
-              'ServiceCharge',
-              'servicecharge',
-              'service_charge'
-            ],
-          );
-          _assignOptionalAmount(
-            extracted,
-            'vat',
-            match,
-            const ['vat', 'VAT'],
-          );
-          String? counterparty = _firstNamedGroup(match, const [
-            'sender',
-            'source',
-            'agent',
-            'payer',
-            'from',
+          if (_hasGroup(match, mapping, 'receiver')) {
+            receiver = _groupValue(match, mapping, 'receiver');
+          }
+          if (creditor != null) extracted['creditor'] = creditor;
+          if (receiver != null) extracted['receiver'] = receiver;
+
+          double? serviceCharge = _extractOptionalAmount(match, mapping, const [
+            'serviceCharge', 'ServiceCharge', 'servicecharge', 'service_charge'
           ]);
-          final rawType = (extracted['type'] ?? pattern.type).toString();
-          final normalized = rawType.toUpperCase();
-          if (normalized.contains('CREDIT')) {
+          double? vat = _extractOptionalAmount(match, mapping, const ['vat', 'VAT']);
+          double? totalDebit = _extractOptionalAmount(
+              match, mapping, const ['totalAmount']);
+          double? totalFee = _extractOptionalAmount(
+              match, mapping, const ['totalFees', 'total_amount']);
+
+          if (serviceCharge != null) extracted['serviceCharge'] = serviceCharge;
+          if (vat != null) extracted['vat'] = vat;
+          if (totalDebit != null) extracted['totalDebit'] = totalDebit;
+          if (totalFee != null) extracted['totalFee'] = totalFee;
+
+          String? counterparty = _firstNamedGroup(match, mapping, const [
+            'sender', 'source', 'agent', 'payer', 'from',
+          ]);
+          final rawType = transactionType;
+          final normalizedType = rawType.toUpperCase();
+          if (normalizedType.contains('CREDIT')) {
             counterparty ??= _fallbackCounterparty(cleanBody);
             if (counterparty != null && counterparty.trim().isNotEmpty) {
               extracted['creditor'] ??= counterparty.trim();
             }
           }
-          if (match.groupNames.contains('time')) {
-            // Date parsing is complex, for now store raw string or try basic parse
-            // Ideally the regex extracts ISO-like or we have a date parser helper
-            extracted['raw_time'] = match.namedGroup('time');
-            extracted['time'] = DateTime.now()
-                .toIso8601String(); // Default to now if parse fails
-          } else {
-            extracted['time'] = DateTime.now().toIso8601String();
+
+          String? time;
+          if (_hasGroup(match, mapping, 'time')) {
+            time = _groupValue(match, mapping, 'time');
           }
+          time ??= messageDate?.toIso8601String();
+          extracted['time'] = time;
 
           final transactionLink =
               TransactionLinkUtils.extractTransactionLinkFromMessage(
             messageBody: cleanBody,
             pattern: pattern,
-            reference: extracted['reference']?.toString(),
+            reference: reference,
           );
           if (transactionLink != null) {
             extracted['transactionLink'] = transactionLink;
           }
 
-          print("debug: account ${extracted["accountNumber"]}");
-          print("debug: amount ${extracted["amount"]}");
-          print("debug: balance ${extracted["currentBalance"]}");
-          print("debug: reference ${extracted["reference"]}");
-          print("debug: receiver ${extracted["receiver"]}");
-
-          if (pattern.refRequired == false && extracted["reference"] == null) {
-            final fallbackDate = messageDate ?? DateTime.now();
-            extracted["reference"] =
-                "${pattern.bankId}_${fallbackDate.toIso8601String()}";
-          }
+          print("debug: account $accountNumber");
+          print("debug: amount $amount");
+          print("debug: balance $currentBalance");
+          print("debug: reference $reference");
+          print("debug: receiver $receiver");
 
           final requiresReference = pattern.refRequired == true;
           final requiresAccount = pattern.hasAccount == true &&
-              match.groupNames.contains('account');
+              _hasGroup(match, mapping, 'account');
+
+          if (amount == null &&
+              serviceCharge != null &&
+              vat != null &&
+              totalDebit != null) {
+            amount = totalDebit - serviceCharge - vat;
+            if (amount != null && amount >= 0) {
+              extracted['amount'] = amount;
+            }
+          }
+          if (!extracted.containsKey('totalFee') &&
+              serviceCharge != null &&
+              vat != null) {
+            extracted['totalFee'] = serviceCharge + vat;
+          }
 
           if (extracted['amount'] == null) {
             print(
                 "✗ Pattern '${pattern.description}' matched but amount missing. Skipping.");
             continue;
           }
-          if (match.groupNames.contains('balance') &&
+          if (_hasGroup(match, mapping, 'balance') &&
               extracted['currentBalance'] == null) {
             print(
                 "✗ Pattern '${pattern.description}' matched but balance missing. Skipping.");
@@ -208,30 +225,55 @@ class PatternParser {
     return null; // No match found
   }
 
+  static String? _groupValue(RegExpMatch match, Map<String, String>? mapping, String name) {
+    if (mapping != null && mapping.containsKey(name)) {
+      final index = int.tryParse(mapping[name]!);
+      if (index != null) return match.group(index);
+    }
+    return match.namedGroup(name);
+  }
+
+  static bool _hasGroup(RegExpMatch match, Map<String, String>? mapping, String name) {
+    if (mapping != null && mapping.containsKey(name)) {
+      final index = int.tryParse(mapping[name]!);
+      if (index != null) return index < match.groupCount + 1;
+    }
+    return match.groupNames.contains(name);
+  }
+
+  static double? _extractOptionalAmount(
+      RegExpMatch match,
+      Map<String, String>? mapping,
+      List<String> groupNames) {
+    for (final name in groupNames) {
+      if (!_hasGroup(match, mapping, name)) continue;
+      final cleaned = _cleanNumber(_groupValue(match, mapping, name));
+      final value = cleaned == null ? null : double.tryParse(cleaned);
+      if (value != null) return value;
+    }
+    return null;
+  }
+
   static void _assignOptionalAmount(
     Map<String, dynamic> target,
     String key,
     RegExpMatch match,
     List<String> groupNames,
   ) {
-    for (final name in groupNames) {
-      if (!match.groupNames.contains(name)) continue;
-      final cleaned = _cleanNumber(match.namedGroup(name));
-      final value = cleaned == null ? null : double.tryParse(cleaned);
-      if (value != null) {
-        target[key] = value;
-      }
-      return;
+    final value = _extractOptionalAmount(match, null, groupNames);
+    if (value != null) {
+      target[key] = value;
     }
   }
 
   static String? _firstNamedGroup(
     RegExpMatch match,
+    Map<String, String>? mapping,
     List<String> groupNames,
   ) {
     for (final name in groupNames) {
-      if (!match.groupNames.contains(name)) continue;
-      final value = match.namedGroup(name);
+      if (!_hasGroup(match, mapping, name)) continue;
+      final value = _groupValue(match, mapping, name);
       if (value != null && value.trim().isNotEmpty) return value;
     }
     return null;


### PR DESCRIPTION
- pattern_parser: added fieldMapping support, _groupValue/_hasGroup helpers, totalDebit/totalFee split, stronger synthesized reference dedup keys
- DB v28: added hasFees/mapping to sms_patterns, totalFee to transactions
- SmsPattern model: added hasFees, fieldMapping fields
- transaction model: added totalFee field
- enrichment_pipeline: wires MerchantNormalizer and CategorizerEnricher
- sms_service: calls enrichment pipeline after Transaction.fromJson
- sms_config_service: persists hasFees/mapping columns
- account_balance_resolver: derives balance from amount+totalFee when currentBalance is null
- transaction_repository: persists/reads totalFee