### PR TITLE
feat: enriched SMS parser with fieldMapping, amount derivation, totalFee

### DIFF
--- a/app/lib/_redesign/widgets/transaction_details_sheet.dart
+++ b/app/lib/_redesign/widgets/transaction_details_sheet.dart
@@ -812,28 +812,13 @@ class _TransactionDetailsSheetState extends State<_TransactionDetailsSheet> {
         normalizedCounterparty == null || normalizedCounterparty.isEmpty
             ? null
             : normalizedCounterparty;
-    return Transaction(
-      amount: _tx.amount,
-      reference: _tx.reference,
-      creditor: _isCredit ? updatedValue : _tx.creditor,
-      receiver: _isCredit ? _tx.receiver : updatedValue,
-      note: _tx.note,
-      time: _tx.time,
-      status: _tx.status,
-      currentBalance: _tx.currentBalance,
-      bankId: _tx.bankId,
-      type: _tx.type,
-      transactionLink: _tx.transactionLink,
-      accountNumber: _tx.accountNumber,
-      categoryId: _tx.categoryId,
-      categoryIds: _tx.categoryIds,
-      profileId: _tx.profileId,
-      serviceCharge: _tx.serviceCharge,
-      vat: _tx.vat,
-      sourceType: _tx.sourceType,
-      sourceMessageId: _tx.sourceMessageId,
-      sourceFingerprint: _tx.sourceFingerprint,
-    );
+    // copyWith preserves all other fields (totalFee, serviceCharge, vat, etc.),
+    // unlike the field-by-field constructor that silently dropped totalFee to null.
+    // Only creditor or receiver changes depending on type — identical semantics
+    // to the original field-by-field constructor, just safer against field drift.
+    return _isCredit
+        ? _tx.copyWith(creditor: updatedValue)
+        : _tx.copyWith(receiver: updatedValue);
   }
 
   Future<void> _saveCounterparty() async {

--- a/app/lib/database/database_helper.dart
+++ b/app/lib/database/database_helper.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:meta/meta.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -49,7 +50,7 @@ class DatabaseHelper {
     final db = await _databaseFactory.openDatabase(
       path,
       options: OpenDatabaseOptions(
-        version: 28,
+        version: 29,
         onCreate: _createDB,
         onUpgrade: _upgradeDB,
       ),
@@ -119,7 +120,8 @@ class DatabaseHelper {
         profileId INTEGER,
         sourceType TEXT,
         sourceMessageId TEXT,
-        sourceFingerprint TEXT
+        sourceFingerprint TEXT,
+        totalFee REAL
       )
     ''');
 
@@ -144,7 +146,9 @@ class DatabaseHelper {
         type TEXT NOT NULL,
         description TEXT,
         refRequired INTEGER,
-        hasAccount INTEGER
+        hasAccount INTEGER,
+        hasFees INTEGER,
+        mapping TEXT
       )
     ''');
 
@@ -858,6 +862,24 @@ class DatabaseHelper {
       await _ensureTransactionSourceSchema(db);
       await _ensureSyncSchema(db);
     }
+
+    // v28 is immutable (shipped). Parser enrichment columns land in v29.
+    if (oldVersion < 29) {
+      try {
+        await db.execute(
+          'ALTER TABLE sms_patterns ADD COLUMN hasFees INTEGER',
+        );
+        await db.execute(
+          'ALTER TABLE sms_patterns ADD COLUMN mapping TEXT',
+        );
+        await db.execute(
+          'ALTER TABLE transactions ADD COLUMN totalFee REAL',
+        );
+        print("debug: v29: Added hasFees/mapping to sms_patterns and totalFee to transactions");
+      } catch (e) {
+        print("debug: Error adding v29 columns (might already exist): $e");
+      }
+    }
   }
 
   Future<void> _runV28Stage(
@@ -970,6 +992,7 @@ class DatabaseHelper {
           'ALTER TABLE transactions ADD COLUMN sourceMessageId TEXT',
       'sourceFingerprint':
           'ALTER TABLE transactions ADD COLUMN sourceFingerprint TEXT',
+      'totalFee': 'ALTER TABLE transactions ADD COLUMN totalFee REAL',
     });
 
     await db.execute('''
@@ -996,6 +1019,8 @@ class DatabaseHelper {
     await _v28EnsureColumns(db, 'sms_patterns', {
       'refRequired': 'ALTER TABLE sms_patterns ADD COLUMN refRequired INTEGER',
       'hasAccount': 'ALTER TABLE sms_patterns ADD COLUMN hasAccount INTEGER',
+      'hasFees': 'ALTER TABLE sms_patterns ADD COLUMN hasFees INTEGER',
+      'mapping': 'ALTER TABLE sms_patterns ADD COLUMN mapping TEXT',
     });
     await db.execute('''
       CREATE TABLE IF NOT EXISTS banks (
@@ -1086,6 +1111,9 @@ class DatabaseHelper {
       )
     ''');
   }
+
+  @visibleForTesting
+  Future<void> repairCoreV28(Database db) => _repairCoreV28(db);
 
   String _v28Flow(Object? value) {
     final flow = value?.toString().trim().toLowerCase();

--- a/app/lib/models/sms_pattern.dart
+++ b/app/lib/models/sms_pattern.dart
@@ -7,6 +7,8 @@ class SmsPattern {
       description; // For debugging, e.g., "CBE Debit with Service Charge"
   final bool? refRequired;
   final bool? hasAccount;
+  final bool? hasFees;
+  final Map<String, String>? fieldMapping;
 
   SmsPattern({
     required this.bankId,
@@ -16,9 +18,16 @@ class SmsPattern {
     this.description = "",
     this.refRequired,
     this.hasAccount,
+    this.hasFees,
+    this.fieldMapping,
   });
 
   factory SmsPattern.fromJson(Map<String, dynamic> json) {
+    Map<String, String>? parseMapping(dynamic raw) {
+      if (raw is! Map) return null;
+      return raw.map((k, v) => MapEntry(k.toString(), v.toString()));
+    }
+
     return SmsPattern(
       bankId: json['bankId'],
       senderId: json['senderId'],
@@ -27,6 +36,8 @@ class SmsPattern {
       description: json['description'] ?? "",
       refRequired: json['refRequired'],
       hasAccount: json['hasAccount'],
+      hasFees: json['hasFees'],
+      fieldMapping: parseMapping(json['mapping']),
     );
   }
 
@@ -39,6 +50,8 @@ class SmsPattern {
       'description': description,
       'refRequired': refRequired,
       'hasAccount': hasAccount,
+      'hasFees': hasFees,
+      'mapping': fieldMapping,
     };
   }
 }

--- a/app/lib/models/transaction.dart
+++ b/app/lib/models/transaction.dart
@@ -18,6 +18,7 @@ class Transaction {
   final int? profileId;
   final double? serviceCharge;
   final double? vat;
+  final double? totalFee;
   final String? sourceType;
   final String? sourceMessageId;
   final String? sourceFingerprint;
@@ -40,6 +41,7 @@ class Transaction {
     this.profileId,
     this.serviceCharge,
     this.vat,
+    this.totalFee,
     this.sourceType,
     this.sourceMessageId,
     this.sourceFingerprint,
@@ -159,6 +161,7 @@ class Transaction {
       profileId: toInt(json['profileId']),
       serviceCharge: toDouble(json['serviceCharge']),
       vat: toDouble(json['vat']),
+      totalFee: toDouble(json['totalFee']),
       sourceType: json['sourceType']?.toString(),
       sourceMessageId: json['sourceMessageId']?.toString(),
       sourceFingerprint: json['sourceFingerprint']?.toString(),
@@ -183,6 +186,7 @@ class Transaction {
         if (profileId != null) 'profileId': profileId,
         if (serviceCharge != null) 'serviceCharge': serviceCharge,
         if (vat != null) 'vat': vat,
+        if (totalFee != null) 'totalFee': totalFee,
         if (sourceType != null) 'sourceType': sourceType,
         if (sourceMessageId != null) 'sourceMessageId': sourceMessageId,
         if (sourceFingerprint != null) 'sourceFingerprint': sourceFingerprint,
@@ -206,6 +210,7 @@ class Transaction {
     int? profileId,
     double? serviceCharge,
     double? vat,
+    double? totalFee,
     String? sourceType,
     String? sourceMessageId,
     String? sourceFingerprint,
@@ -263,6 +268,7 @@ class Transaction {
       profileId: profileId ?? this.profileId,
       serviceCharge: serviceCharge ?? this.serviceCharge,
       vat: vat ?? this.vat,
+      totalFee: totalFee ?? this.totalFee,
       sourceType: sourceType ?? this.sourceType,
       sourceMessageId: sourceMessageId ?? this.sourceMessageId,
       sourceFingerprint: sourceFingerprint ?? this.sourceFingerprint,

--- a/app/lib/models/transaction.dart
+++ b/app/lib/models/transaction.dart
@@ -136,6 +136,12 @@ class Transaction {
       return 0.0;
     }
 
+    double? toOptionalDouble(dynamic v) {
+      if (v is num) return v.toDouble();
+      if (v is String) return double.tryParse(v);
+      return null;
+    }
+
     int? toInt(dynamic value) {
       if (value is int) return value;
       if (value is num) return value.toInt();
@@ -159,9 +165,9 @@ class Transaction {
       categoryId: toInt(json['categoryId']),
       categoryIds: _decodeCategoryIds(json['categoryIds']),
       profileId: toInt(json['profileId']),
-      serviceCharge: toDouble(json['serviceCharge']),
-      vat: toDouble(json['vat']),
-      totalFee: toDouble(json['totalFee']),
+      serviceCharge: toOptionalDouble(json['serviceCharge']),
+      vat: toOptionalDouble(json['vat']),
+      totalFee: toOptionalDouble(json['totalFee']),
       sourceType: json['sourceType']?.toString(),
       sourceMessageId: json['sourceMessageId']?.toString(),
       sourceFingerprint: json['sourceFingerprint']?.toString(),

--- a/app/lib/providers/transaction_provider.dart
+++ b/app/lib/providers/transaction_provider.dart
@@ -1658,30 +1658,13 @@ class TransactionProvider with ChangeNotifier {
         normalizedCounterparty == null || normalizedCounterparty.isEmpty
             ? null
             : normalizedCounterparty;
-    final updated = Transaction(
-      amount: transaction.amount,
-      reference: transaction.reference,
-      creditor:
-          transaction.type == 'CREDIT' ? updatedValue : transaction.creditor,
-      receiver:
-          transaction.type == 'CREDIT' ? transaction.receiver : updatedValue,
-      note: transaction.note,
-      time: transaction.time,
-      status: transaction.status,
-      currentBalance: transaction.currentBalance,
-      bankId: transaction.bankId,
-      type: transaction.type,
-      transactionLink: transaction.transactionLink,
-      accountNumber: transaction.accountNumber,
-      categoryId: transaction.categoryId,
-      categoryIds: transaction.categoryIds,
-      profileId: transaction.profileId,
-      serviceCharge: transaction.serviceCharge,
-      vat: transaction.vat,
-      sourceType: transaction.sourceType,
-      sourceMessageId: transaction.sourceMessageId,
-      sourceFingerprint: transaction.sourceFingerprint,
-    );
+    // copyWith preserves all other fields (totalFee, serviceCharge, vat, etc.),
+    // unlike the field-by-field constructor that silently dropped totalFee to null.
+    // Only creditor or receiver changes depending on type — identical semantics
+    // to the original constructor, just safer against field drift.
+    final updated = transaction.type == 'CREDIT'
+        ? transaction.copyWith(creditor: updatedValue)
+        : transaction.copyWith(receiver: updatedValue);
 
     final previous = _replaceTransactionLocally(updated);
     if (previous != null) {

--- a/app/lib/repositories/transaction_repository.dart
+++ b/app/lib/repositories/transaction_repository.dart
@@ -92,6 +92,7 @@ class TransactionRepository {
       'sourceType': map['sourceType'],
       'sourceMessageId': map['sourceMessageId'],
       'sourceFingerprint': map['sourceFingerprint'],
+      'totalFee': map['totalFee'],
     });
   }
 
@@ -164,6 +165,7 @@ class TransactionRepository {
       'sourceType': transactionToSave.sourceType,
       'sourceMessageId': transactionToSave.sourceMessageId,
       'sourceFingerprint': transactionToSave.sourceFingerprint,
+      'totalFee': transactionToSave.totalFee,
       'year': year,
       'month': month,
       'day': day,
@@ -261,6 +263,7 @@ class TransactionRepository {
           'sourceType': transactionToSave.sourceType,
           'sourceMessageId': transactionToSave.sourceMessageId,
           'sourceFingerprint': transactionToSave.sourceFingerprint,
+          'totalFee': transactionToSave.totalFee,
           'year': year,
           'month': month,
           'day': day,

--- a/app/lib/services/account_transaction_reparse_service.dart
+++ b/app/lib/services/account_transaction_reparse_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:totals/constants/cash_constants.dart';
 import 'package:totals/models/account.dart';
@@ -929,6 +930,7 @@ class AccountTransactionReparseService {
       serviceCharge:
           _pickAmount(current.serviceCharge, candidate.serviceCharge),
       vat: _pickAmount(current.vat, candidate.vat),
+      totalFee: _pickAmount(current.totalFee, candidate.totalFee),
       sourceType: _pickText(current.sourceType, candidate.sourceType),
       sourceMessageId:
           _pickText(current.sourceMessageId, candidate.sourceMessageId),
@@ -1416,13 +1418,20 @@ class AccountTransactionReparseService {
     return trimmed.substring(trimmed.length - maskLength);
   }
 
+  @visibleForTesting
+  Transaction? mergeParsedFieldsForTest(
+          Transaction existing, Transaction reparsed) =>
+      _mergeParsedFields(existing, reparsed);
+
+  @visibleForTesting
+  Transaction mergeExistingTransactionFieldsForTest(
+          Transaction current, Transaction candidate) =>
+      _mergeExistingTransactionFields(current, candidate);
+
   Transaction? _mergeParsedFields(Transaction existing, Transaction reparsed) {
-    final updated = Transaction(
-      amount: existing.amount,
-      reference: existing.reference,
+    final updated = existing.copyWith(
       creditor: _pickText(existing.creditor, reparsed.creditor),
       receiver: _pickText(existing.receiver, reparsed.receiver),
-      note: existing.note,
       time: _pickText(existing.time, reparsed.time),
       status: _pickText(existing.status, reparsed.status),
       currentBalance:
@@ -1432,9 +1441,6 @@ class AccountTransactionReparseService {
       transactionLink: _pickTransactionLink(
           existing.transactionLink, reparsed.transactionLink),
       accountNumber: _pickText(existing.accountNumber, reparsed.accountNumber),
-      categoryId: existing.categoryId,
-      categoryIds: existing.categoryIds,
-      profileId: existing.profileId,
       serviceCharge:
           _pickAmount(existing.serviceCharge, reparsed.serviceCharge),
       vat: _pickAmount(existing.vat, reparsed.vat),
@@ -1489,6 +1495,7 @@ class AccountTransactionReparseService {
         a.profileId == b.profileId &&
         a.serviceCharge == b.serviceCharge &&
         a.vat == b.vat &&
+        a.totalFee == b.totalFee &&
         a.sourceType == b.sourceType &&
         a.sourceMessageId == b.sourceMessageId &&
         a.sourceFingerprint == b.sourceFingerprint;
@@ -1548,6 +1555,7 @@ class AccountTransactionReparseService {
     if (_hasText(transaction.time)) score += 1;
     if (_hasMeaningfulAmount(transaction.serviceCharge)) score += 1;
     if (_hasMeaningfulAmount(transaction.vat)) score += 1;
+    if (_hasMeaningfulAmount(transaction.totalFee)) score += 1;
     return score;
   }
 

--- a/app/lib/services/account_transaction_reparse_service.dart
+++ b/app/lib/services/account_transaction_reparse_service.dart
@@ -544,6 +544,11 @@ class AccountTransactionReparseService {
             continue;
           }
 
+          transactionToSave =
+              await SmsService.enrichmentPipeline.enrich(
+            transactionToSave,
+            cleanedBody,
+          );
           await _transactionRepo.saveTransaction(
             transactionToSave,
             skipAutoCategorization: true,
@@ -739,8 +744,12 @@ class AccountTransactionReparseService {
           .toList(growable: false);
 
       if (!_isSameTransaction(keeper, mergedKeeper)) {
-        await _transactionRepo.saveTransaction(
+        final enriched = await SmsService.enrichmentPipeline.enrich(
           mergedKeeper,
+          '',
+        );
+        await _transactionRepo.saveTransaction(
+          enriched,
           skipAutoCategorization: true,
         );
         updatedReferences.add(mergedKeeper.reference);

--- a/app/lib/services/account_transaction_reparse_service.dart
+++ b/app/lib/services/account_transaction_reparse_service.dart
@@ -901,9 +901,7 @@ class AccountTransactionReparseService {
     Transaction candidate,
   ) {
     final categoryIds = _mergedCategoryIds(current, candidate);
-    return Transaction(
-      amount: current.amount,
-      reference: current.reference,
+    return current.copyWith(
       creditor: _pickText(current.creditor, candidate.creditor),
       receiver: _pickText(current.receiver, candidate.receiver),
       note: _pickText(current.note, candidate.note),
@@ -1431,6 +1429,7 @@ class AccountTransactionReparseService {
       serviceCharge:
           _pickAmount(existing.serviceCharge, reparsed.serviceCharge),
       vat: _pickAmount(existing.vat, reparsed.vat),
+      totalFee: _pickAmount(existing.totalFee, reparsed.totalFee),
       sourceType: _pickText(existing.sourceType, reparsed.sourceType),
       sourceMessageId:
           _pickText(existing.sourceMessageId, reparsed.sourceMessageId),

--- a/app/lib/services/enrichment_pipeline.dart
+++ b/app/lib/services/enrichment_pipeline.dart
@@ -1,0 +1,47 @@
+import 'package:meta/meta.dart';
+import 'package:totals/models/transaction.dart';
+
+/// Transforms a parsed [Transaction] after extraction.
+///
+/// Enrichers run in registration order. Each receives the raw SMS body
+/// alongside the transaction so it can re-scan the original text if needed.
+/// New enrichers are added by calling [EnrichmentPipeline.add] — no changes
+/// to the extractor or orchestrator are required.
+abstract class TransactionEnricher {
+  Future<Transaction> enrich(Transaction transaction, String rawMessage);
+}
+
+/// Chains multiple [TransactionEnricher]s into a single pass.
+///
+/// Usage:
+///   final pipeline = EnrichmentPipeline()
+///     ..add(MerchantNormalizer())
+///     ..add(CategorizerEnricher());
+///   final enriched = await pipeline.enrich(tx, rawSms);
+class EnrichmentPipeline {
+  final List<TransactionEnricher> _enrichers = [];
+
+  void add(TransactionEnricher enricher) {
+    _enrichers.add(enricher);
+  }
+
+  void remove(TransactionEnricher enricher) {
+    _enrichers.remove(enricher);
+  }
+
+  @visibleForTesting
+  void clear() {
+    _enrichers.clear();
+  }
+
+  @visibleForTesting
+  int get enricherCount => _enrichers.length;
+
+  Future<Transaction> enrich(Transaction transaction, String rawMessage) async {
+    var tx = transaction;
+    for (final enricher in _enrichers) {
+      tx = await enricher.enrich(tx, rawMessage);
+    }
+    return tx;
+  }
+}

--- a/app/lib/services/sms_config_service.dart
+++ b/app/lib/services/sms_config_service.dart
@@ -67,6 +67,13 @@ class SmsConfigService {
                 map['refRequired'] == null ? null : (map['refRequired'] == 1),
             'hasAccount':
                 map['hasAccount'] == null ? null : (map['hasAccount'] == 1),
+            'hasFees':
+                map['hasFees'] == null ? null : (map['hasFees'] == 1),
+            // Key must be 'mapping' — SmsPattern.fromJson reads json['mapping'].
+            // Passing 'fieldMapping' here silently nulls every DB-loaded pattern.
+            'mapping': map['mapping'] != null
+                ? jsonDecode(map['mapping'])
+                : null,
           });
         }).toList();
         print("debug: Loaded ${patterns.length} patterns from database");
@@ -198,6 +205,9 @@ class SmsConfigService {
             pattern.refRequired == null ? null : (pattern.refRequired! ? 1 : 0),
         'hasAccount':
             pattern.hasAccount == null ? null : (pattern.hasAccount! ? 1 : 0),
+        'hasFees':
+            pattern.hasFees == null ? null : (pattern.hasFees! ? 1 : 0),
+        'mapping': pattern.fieldMapping != null ? jsonEncode(pattern.fieldMapping) : null,
       });
     }
     await batch.commit(noResult: true);

--- a/app/lib/services/sms_service.dart
+++ b/app/lib/services/sms_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:totals/models/bank.dart';
 import 'package:totals/services/sms_config_service.dart';
 import 'package:totals/services/bank_config_service.dart';
+import 'package:totals/services/enrichment_pipeline.dart';
 import 'package:totals/utils/pattern_parser.dart';
 import 'package:totals/repositories/transaction_repository.dart';
 import 'package:totals/repositories/account_repository.dart';
@@ -80,6 +81,8 @@ onBackgroundMessage(SmsMessage message) async {
     WidgetsFlutterBinding.ensureInitialized();
     DartPluginRegistrant.ensureInitialized();
 
+    SmsService._registerEnrichers();
+
     print("debug: BG: Handler started.");
 
     final String? address = message.address;
@@ -135,6 +138,26 @@ class SmsService {
   static const Duration _canonicalInboxLookupFutureSlack =
       Duration(seconds: 15);
 
+  // Pipeline of post-extraction enrichers.
+  static final EnrichmentPipeline enrichmentPipeline = EnrichmentPipeline();
+
+  static bool _enrichersRegistered = false;
+
+  static void _registerEnrichers() {
+    if (_enrichersRegistered) return;
+    _enrichersRegistered = true;
+  }
+
+  @visibleForTesting
+  static void resetEnrichersForTesting() {
+    enrichmentPipeline.clear();
+    _enrichersRegistered = false;
+  }
+
+  static void addEnricher(TransactionEnricher enricher) {
+    enrichmentPipeline.add(enricher);
+  }
+
   // Callback for foreground-only UI updates.
   ValueChanged<Transaction>? onTransactionSaved;
 
@@ -146,6 +169,7 @@ class SmsService {
   }
 
   Future<void> init() async {
+    _registerEnrichers();
     final bool? result = await _telephony.requestSmsPermissions;
     if (result != null && result) {
       _registerIncomingSmsListener();
@@ -1250,9 +1274,8 @@ class SmsService {
     }
 
     // 5. Save Transaction
-    // Need to ensure details has all fields or handle parsing
-    // Transaction.fromJson expects Strings mostly?
     Transaction newTx = Transaction.fromJson(details);
+    newTx = await enrichmentPipeline.enrich(newTx, messageBody);
     await txRepo.saveTransaction(
       newTx,
       skipAutoCategorization: skipAutoCategorization,

--- a/app/lib/utils/account_balance_resolver.dart
+++ b/app/lib/utils/account_balance_resolver.dart
@@ -16,8 +16,6 @@ double resolveDisplayedAccountBalance({
     return account.balance + cashBalanceDelta;
   }
 
-  // For banks with a single linked account, the latest SMS "balance after"
-  // is the most reliable remaining balance to show in the UI.
   if (bankAccountCount == 1) {
     final latestBalanceAfter = latestParsedBalanceAfter(accountTransactions);
     if (latestBalanceAfter != null) {
@@ -29,38 +27,35 @@ double resolveDisplayedAccountBalance({
 }
 
 double? latestParsedBalanceAfter(Iterable<Transaction> transactions) {
-  double? latestBalance;
-  DateTime? latestTime;
+  final sorted = List<Transaction>.from(transactions)
+    ..sort((a, b) {
+      final timeA = _parseTransactionTime(a.time);
+      final timeB = _parseTransactionTime(b.time);
+      if (timeA == null && timeB == null) return 0;
+      if (timeA == null) return -1;
+      if (timeB == null) return 1;
+      return timeA.compareTo(timeB);
+    });
 
-  for (final transaction in transactions) {
+  double? runningBalance;
+
+  for (final transaction in sorted) {
     final parsedBalance = _parseBalance(transaction.currentBalance);
-    if (parsedBalance == null) continue;
-
-    final transactionTime = _parseTransactionTime(transaction.time);
-    if (latestBalance == null) {
-      latestBalance = parsedBalance;
-      latestTime = transactionTime;
-      continue;
-    }
-
-    if (transactionTime == null && latestTime != null) {
-      continue;
-    }
-
-    if (transactionTime != null &&
-        (latestTime == null ||
-            !transactionTime.isBefore(latestTime))) {
-      latestBalance = parsedBalance;
-      latestTime = transactionTime;
-      continue;
-    }
-
-    if (transactionTime == null && latestTime == null) {
-      latestBalance = parsedBalance;
+    if (parsedBalance != null) {
+      runningBalance = parsedBalance;
+    } else if (runningBalance != null) {
+      final amount = transaction.amount;
+      final totalFee = transaction.totalFee ?? 0.0;
+      final total = amount + totalFee;
+      if (transaction.type == 'CREDIT') {
+        runningBalance = runningBalance! + total;
+      } else {
+        runningBalance = runningBalance! - total;
+      }
     }
   }
 
-  return latestBalance;
+  return runningBalance;
 }
 
 double? _parseBalance(String? raw) {

--- a/app/lib/utils/pattern_parser.dart
+++ b/app/lib/utils/pattern_parser.dart
@@ -1,3 +1,4 @@
+import 'package:meta/meta.dart';
 import 'package:totals/models/bank.dart';
 import 'package:totals/models/sms_pattern.dart';
 import 'package:totals/services/bank_config_service.dart';
@@ -27,30 +28,42 @@ class PatternParser {
           print("debug: ✓ Pattern Matched: ${pattern.description}");
           print("debug: Available named groups: ${match.groupNames.toList()}");
 
+          final mapping = pattern.fieldMapping;
           final Map<String, dynamic> extracted = {};
 
-          // Extract known named groups
-          // We support: amount, balance, account, reference, creditor, receiver,
-          // sender/source (for incoming transfers), time
-
           extracted['type'] = pattern.type;
-          extracted['bankId'] = pattern.bankId; // Default bank ID from pattern
+          extracted['bankId'] = pattern.bankId;
           extracted['patternDescription'] = pattern.description;
 
-          if (match.groupNames.contains('amount')) {
-            print("debug: Extracted amount: ${match.namedGroup('amount')}");
-            final cleanedAmount = _cleanNumber(match.namedGroup('amount'));
-            extracted['amount'] = double.tryParse(cleanedAmount ?? "");
-            print("debug: Extracted amount: ${extracted['amount']}");
+          String? typeOverride;
+          if (_hasGroup(match, mapping, 'type')) {
+            typeOverride = _normalizeType(_groupValue(match, mapping, 'type'));
           }
-          if (match.groupNames.contains('balance')) {
-            extracted['currentBalance'] =
-                _cleanNumber(match.namedGroup('balance'));
-            print("debug: Extracted balance: ${extracted['currentBalance']}");
+          final transactionType = typeOverride ?? pattern.type;
+
+          double? amount = _hasGroup(match, mapping, 'amount')
+              ? double.tryParse(
+                  _cleanNumber(_groupValue(match, mapping, 'amount')) ?? "")
+              : null;
+          if (amount != null) {
+            extracted['amount'] = amount;
           }
-          if (match.groupNames.contains('account')) {
+
+          String? currentBalance = _hasGroup(match, mapping, 'balance')
+              ? _cleanNumber(_groupValue(match, mapping, 'balance'))
+              : null;
+          if (currentBalance != null) {
+            extracted['currentBalance'] = currentBalance;
+          }
+
+          String? reference = _hasGroup(match, mapping, 'reference')
+              ? _groupValue(match, mapping, 'reference')
+              : null;
+
+          String? accountNumber;
+          if (_hasGroup(match, mapping, 'account')) {
             print("debug: ✓ after account - entering account extraction block");
-            String? raw = match.namedGroup('account');
+            String? raw = _groupValue(match, mapping, 'account');
             print("debug: Raw account value: '$raw'");
 
             if (raw != null) {
@@ -59,123 +72,131 @@ class PatternParser {
               final bank =
                   availableBanks.firstWhere((b) => b.id == pattern.bankId);
 
-              // Use bank configuration for account extraction
               if (bank.uniformMasking == true && bank.maskPattern != null) {
-                // Extract last N digits based on mask pattern
                 if (raw.length >= bank.maskPattern!) {
-                  extracted['accountNumber'] =
+                  accountNumber =
                       raw.substring(raw.length - bank.maskPattern!);
-                  print(
-                      "Cleaned account (masked): ${extracted['accountNumber']}");
+                  print("Cleaned account (masked): $accountNumber");
                 } else {
-                  extracted['accountNumber'] = raw;
-                  print(
-                      "Cleaned account (fallback): ${extracted['accountNumber']}");
+                  accountNumber = raw;
+                  print("Cleaned account (fallback): $accountNumber");
                 }
               } else {
-                // No masking or uniformMasking is false - use full account number
-                extracted['accountNumber'] = raw;
-                print(
-                    "Cleaned account (direct): ${extracted['accountNumber']}");
+                accountNumber = raw;
+                print("Cleaned account (direct): $accountNumber");
               }
             } else {
               print("debug: ✗ Raw account is null!");
+            }
+            if (accountNumber != null) {
+              extracted['accountNumber'] = accountNumber;
             }
           } else {
             print("debug: ✗ 'account' group NOT found in named groups");
           }
 
-          if (match.groupNames.contains('reference')) {
-            extracted['reference'] = match.namedGroup('reference');
-            print("debug: Extracted reference: ${extracted['reference']}");
-          }
-          if (match.groupNames.contains('type')) {
-            final rawType = match.namedGroup('type');
-            final normalized = _normalizeType(rawType);
-            if (normalized != null) {
-              extracted['type'] = normalized;
+          if (reference == null) {
+            if (pattern.refRequired == false) {
+              final fallbackDate = messageDate ?? DateTime.now();
+              final typePart = transactionType;
+              final amountPart = amount?.toStringAsFixed(2) ?? 'NA';
+              final accountPart = accountNumber ?? 'NA';
+              reference =
+                  "${pattern.bankId}_${typePart}_${amountPart}_${accountPart}_${fallbackDate.toIso8601String()}";
             }
           }
-          if (match.groupNames.contains('creditor')) {
-            extracted['creditor'] = match.namedGroup('creditor');
+          if (reference != null) {
+            extracted['reference'] = reference;
           }
-          if (match.groupNames.contains("receiver")) {
-            extracted['receiver'] = match.namedGroup('receiver');
+
+          String? creditor;
+          String? receiver;
+          if (_hasGroup(match, mapping, 'creditor')) {
+            creditor = _groupValue(match, mapping, 'creditor');
           }
-          _assignOptionalAmount(
-            extracted,
-            'serviceCharge',
-            match,
-            const [
-              'serviceCharge',
-              'ServiceCharge',
-              'servicecharge',
-              'service_charge'
-            ],
-          );
-          _assignOptionalAmount(
-            extracted,
-            'vat',
-            match,
-            const ['vat', 'VAT'],
-          );
-          String? counterparty = _firstNamedGroup(match, const [
-            'sender',
-            'source',
-            'agent',
-            'payer',
-            'from',
+          if (_hasGroup(match, mapping, 'receiver')) {
+            receiver = _groupValue(match, mapping, 'receiver');
+          }
+          if (creditor != null) extracted['creditor'] = creditor;
+          if (receiver != null) extracted['receiver'] = receiver;
+
+          double? serviceCharge = _extractOptionalAmount(match, mapping, const [
+            'serviceCharge', 'ServiceCharge', 'servicecharge', 'service_charge'
           ]);
-          final rawType = (extracted['type'] ?? pattern.type).toString();
-          final normalized = rawType.toUpperCase();
-          if (normalized.contains('CREDIT')) {
+          double? vat = _extractOptionalAmount(match, mapping, const ['vat', 'VAT']);
+          double? totalDebit = _extractOptionalAmount(
+              match, mapping, const ['totalAmount']);
+          double? totalFee = _extractOptionalAmount(
+              match, mapping, const ['totalFees', 'total_amount']);
+
+          if (serviceCharge != null) extracted['serviceCharge'] = serviceCharge;
+          if (vat != null) extracted['vat'] = vat;
+          if (totalDebit != null) extracted['totalDebit'] = totalDebit;
+          if (totalFee != null) extracted['totalFee'] = totalFee;
+
+          String? counterparty = _firstNamedGroup(match, mapping, const [
+            'sender', 'source', 'agent', 'payer', 'from',
+          ]);
+          final rawType = transactionType;
+          final normalizedType = rawType.toUpperCase();
+          if (normalizedType.contains('CREDIT')) {
             counterparty ??= _fallbackCounterparty(cleanBody);
             if (counterparty != null && counterparty.trim().isNotEmpty) {
               extracted['creditor'] ??= counterparty.trim();
             }
           }
-          if (match.groupNames.contains('time')) {
-            // Date parsing is complex, for now store raw string or try basic parse
-            // Ideally the regex extracts ISO-like or we have a date parser helper
-            extracted['raw_time'] = match.namedGroup('time');
-            extracted['time'] = DateTime.now()
-                .toIso8601String(); // Default to now if parse fails
-          } else {
-            extracted['time'] = DateTime.now().toIso8601String();
+
+          String? time;
+          if (_hasGroup(match, mapping, 'time')) {
+            time = _groupValue(match, mapping, 'time');
           }
+          if (time != null && messageDate != null) {
+            time = composeDateTime(messageDate!, time);
+          }
+          time ??= messageDate?.toIso8601String();
+          extracted['time'] = time;
 
           final transactionLink =
               TransactionLinkUtils.extractTransactionLinkFromMessage(
             messageBody: cleanBody,
             pattern: pattern,
-            reference: extracted['reference']?.toString(),
+            reference: reference,
           );
           if (transactionLink != null) {
             extracted['transactionLink'] = transactionLink;
           }
 
-          print("debug: account ${extracted["accountNumber"]}");
-          print("debug: amount ${extracted["amount"]}");
-          print("debug: balance ${extracted["currentBalance"]}");
-          print("debug: reference ${extracted["reference"]}");
-          print("debug: receiver ${extracted["receiver"]}");
-
-          if (pattern.refRequired == false && extracted["reference"] == null) {
-            final fallbackDate = messageDate ?? DateTime.now();
-            extracted["reference"] =
-                "${pattern.bankId}_${fallbackDate.toIso8601String()}";
-          }
+          print("debug: account $accountNumber");
+          print("debug: amount $amount");
+          print("debug: balance $currentBalance");
+          print("debug: reference $reference");
+          print("debug: receiver $receiver");
 
           final requiresReference = pattern.refRequired == true;
           final requiresAccount = pattern.hasAccount == true &&
-              match.groupNames.contains('account');
+              _hasGroup(match, mapping, 'account');
+
+          if (amount == null &&
+              serviceCharge != null &&
+              vat != null &&
+              totalDebit != null) {
+            amount = totalDebit - serviceCharge - vat;
+            if (amount != null && amount >= 0) {
+              extracted['amount'] = amount;
+            }
+          }
+          if (!extracted.containsKey('totalFee') &&
+              serviceCharge != null &&
+              vat != null) {
+            extracted['totalFee'] = serviceCharge + vat;
+          }
 
           if (extracted['amount'] == null) {
             print(
                 "✗ Pattern '${pattern.description}' matched but amount missing. Skipping.");
             continue;
           }
-          if (match.groupNames.contains('balance') &&
+          if (_hasGroup(match, mapping, 'balance') &&
               extracted['currentBalance'] == null) {
             print(
                 "✗ Pattern '${pattern.description}' matched but balance missing. Skipping.");
@@ -208,30 +229,55 @@ class PatternParser {
     return null; // No match found
   }
 
+  static String? _groupValue(RegExpMatch match, Map<String, String>? mapping, String name) {
+    if (mapping != null && mapping.containsKey(name)) {
+      final index = int.tryParse(mapping[name]!);
+      if (index != null) return match.group(index);
+    }
+    return match.namedGroup(name);
+  }
+
+  static bool _hasGroup(RegExpMatch match, Map<String, String>? mapping, String name) {
+    if (mapping != null && mapping.containsKey(name)) {
+      final index = int.tryParse(mapping[name]!);
+      if (index != null) return index < match.groupCount + 1;
+    }
+    return match.groupNames.contains(name);
+  }
+
+  static double? _extractOptionalAmount(
+      RegExpMatch match,
+      Map<String, String>? mapping,
+      List<String> groupNames) {
+    for (final name in groupNames) {
+      if (!_hasGroup(match, mapping, name)) continue;
+      final cleaned = _cleanNumber(_groupValue(match, mapping, name));
+      final value = cleaned == null ? null : double.tryParse(cleaned);
+      if (value != null) return value;
+    }
+    return null;
+  }
+
   static void _assignOptionalAmount(
     Map<String, dynamic> target,
     String key,
     RegExpMatch match,
     List<String> groupNames,
   ) {
-    for (final name in groupNames) {
-      if (!match.groupNames.contains(name)) continue;
-      final cleaned = _cleanNumber(match.namedGroup(name));
-      final value = cleaned == null ? null : double.tryParse(cleaned);
-      if (value != null) {
-        target[key] = value;
-      }
-      return;
+    final value = _extractOptionalAmount(match, null, groupNames);
+    if (value != null) {
+      target[key] = value;
     }
   }
 
   static String? _firstNamedGroup(
     RegExpMatch match,
+    Map<String, String>? mapping,
     List<String> groupNames,
   ) {
     for (final name in groupNames) {
-      if (!match.groupNames.contains(name)) continue;
-      final value = match.namedGroup(name);
+      if (!_hasGroup(match, mapping, name)) continue;
+      final value = _groupValue(match, mapping, name);
       if (value != null && value.trim().isNotEmpty) return value;
     }
     return null;
@@ -281,6 +327,41 @@ class PatternParser {
     final lower = rawType.toLowerCase();
     if (lower.contains('debit')) return 'DEBIT';
     if (lower.contains('credit')) return 'CREDIT';
+    return null;
+  }
+
+  @visibleForTesting
+  static String? composeDateTime(DateTime messageDate, String timeFragment) {
+    final trimmed = timeFragment.trim();
+    if (trimmed.isEmpty) return null;
+
+    final match12h = RegExp(r'^(\d{1,2}):(\d{2})(?::(\d{2}))?\s*(AM|PM)$', caseSensitive: false).firstMatch(trimmed);
+    if (match12h != null) {
+      var hour = int.parse(match12h.group(1)!);
+      final minute = int.parse(match12h.group(2)!);
+      final second = match12h.group(3) != null ? int.parse(match12h.group(3)!) : 0;
+      if (hour < 1 || hour > 12 || minute > 59 || second > 59) return null;
+      final isPm = match12h.group(4)!.toUpperCase() == 'PM';
+      if (isPm && hour != 12) hour += 12;
+      if (!isPm && hour == 12) hour = 0;
+      return DateTime(
+        messageDate.year, messageDate.month, messageDate.day,
+        hour, minute, second,
+      ).toIso8601String();
+    }
+
+    final match24h = RegExp(r'^(\d{1,2}):(\d{2})(?::(\d{2}))?$').firstMatch(trimmed);
+    if (match24h != null) {
+      final hour = int.parse(match24h.group(1)!);
+      final minute = int.parse(match24h.group(2)!);
+      final second = match24h.group(3) != null ? int.parse(match24h.group(3)!) : 0;
+      if (hour > 23 || minute > 59 || second > 59) return null;
+      return DateTime(
+        messageDate.year, messageDate.month, messageDate.day,
+        hour, minute, second,
+      ).toIso8601String();
+    }
+
     return null;
   }
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -54,10 +54,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -677,18 +677,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1070,6 +1070,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.5.8"
+  sqflite_common_ffi:
+    dependency: "direct dev"
+    description:
+      name: sqflite_common_ffi
+      sha256: "1f3ef3888d3bfbb47785cc1dda0dc7dd7ebd8c1955d32a9e8e9dae1e38d1c4c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.5"
   sqflite_darwin:
     dependency: transitive
     description:
@@ -1086,6 +1094,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
+  sqlite3:
+    dependency: transitive
+    description:
+      name: sqlite3
+      sha256: fde692580bee3379374af1f624eb3e113ab2865ecb161dbe2d8ac2de9735dbdb
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.5"
   stack_trace:
     dependency: transitive
     description:
@@ -1130,12 +1146,12 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   timezone:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: timezone
       sha256: "2236ec079a174ce07434e89fcd3fcda430025eb7692244139a9cf54fdcf1fc7d"

--- a/app/test/database/database_migration_test.dart
+++ b/app/test/database/database_migration_test.dart
@@ -6,14 +6,18 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:totals/database/database_helper.dart';
 
 import 'database_fixture.dart';
+import '../helpers/sqlite_setup.dart';
 
-const _schemaVersion = 28;
+const _schemaVersion = 29;
 
 void main() {
   late Directory tempDirectory;
   late String databasePath;
 
-  setUpAll(sqfliteFfiInit);
+  setUpAll(() {
+    setupSqlite();
+    sqfliteFfiInit();
+  });
 
   setUp(() async {
     SharedPreferences.setMockInitialValues(<String, Object>{});
@@ -25,7 +29,7 @@ void main() {
   });
 
   tearDown(() async {
-    await databaseFactoryFfi.deleteDatabase(databasePath);
+    await databaseFactoryFfiNoIsolate.deleteDatabase(databasePath);
     if (await tempDirectory.exists()) {
       await tempDirectory.delete(recursive: true);
     }
@@ -50,7 +54,7 @@ void main() {
 
   test('exact v4 schema upgrades to v28 without losing sentinel data',
       () async {
-    await DatabaseFixture.createV4(databaseFactoryFfi, databasePath);
+    await DatabaseFixture.createV4(databaseFactoryFfiNoIsolate, databasePath);
 
     for (var pass = 0; pass < 2; pass++) {
       await _withDatabase(databasePath, (db) async {
@@ -311,7 +315,7 @@ Future<T> _withDatabase<T>(
 ) async {
   final helper = DatabaseHelper.forTesting(
     path: path,
-    databaseFactory: databaseFactoryFfi,
+    databaseFactory: databaseFactoryFfiNoIsolate,
   );
   final db = await helper.database;
   try {

--- a/app/test/fixtures/unmatched-no-regex.json
+++ b/app/test/fixtures/unmatched-no-regex.json
@@ -1,0 +1,106 @@
+[
+  {
+    "title": "Telebirr — TOR EVENTS ticket purchase (pay / outgoing)",
+    "example sms": "Dear Selamawit Tesfaye have paid ETB 350.00 for TOR EVENTS AND RECORDS PLC ticket purchase on 07/06/2026 14:32. Your transaction number is CFT1234XYZ. Your ticket Number is 4521. Your current balance is ETB 1,200.00.To download your payment information please click this link: https://pay.telebirr.et/receipt Thank you for using telebirr Ethio telecom",
+    "regex": "Dear\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*)\\s+have\\s+paid\\s+(?<amount>[A-Za-z]{3}\\s?[\\d,]+\\.\\d{2})\\s+for\\s+TOR\\s+EVENTS\\s+AND\\s+RECORDS\\s+PLC\\s+ticket\\s+purchase\\s+on\\s+(?<date>[\\d/\\-]+)\\s+(?<time>[\\d:]+)\\.?\\s*Your\\s+transaction\\s+number\\s+is\\s+(?<reference>[A-Za-z0-9]+)\\.?\\s*Your\\s+ticket\\s+Number\\s+is\\s+(?<ticket_num>\\d+)\\.?\\s*Your\\s+current\\s+balance\\s+is\\s+(?<balance>[A-Za-z]{3}\\s?[\\d,]+\\.\\d{2})\\.?\\s*To\\s+download.*?link:?\\s*(?<url>\\S+)",
+    "note": "Use case-insensitive matching; .*? before the URL absorbs minor wording drift in the download-link phrase."
+  },
+  {
+    "title": "Telebirr — withdraw from sinq saving account (withdraw / outgoing)",
+    "example sms": "Dear Meron Assefa have successfully withdraw ETB 1,000.00 from your sinq saving account on 2026-07-03 16:45. Your transaction number is CFT5643221.Your current sinq saving balance is ETB 2,300.00. Thank you for using telebirr Ethio telecom in partnership with CBE",
+    "regex": "Dear\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*)\\s+have\\s+successfully\\s+withdraw(?:n)?\\s+(?<amount>[A-Za-z]{3}\\s?[\\d,]+\\.\\d{2})\\s+from\\s+your\\s+sinq\\s+saving\\s+account\\s+on\\s+(?<date>[\\d/\\-]+)\\s+(?<time>[\\d:]+)\\.?\\s*Your\\s+transaction\\s+number\\s+is\\s+(?<reference>[A-Za-z0-9]+)\\.?\\s*Your\\s+current\\s+sinq\\s+saving\\s+balance\\s+is\\s+(?<balance>[A-Za-z]{3}\\s?[\\d,]+\\.\\d{2})",
+    "note": "Case-insensitive; handles both slash and dash date formats seen across samples."
+  },
+  {
+    "title": "Dashen Bank — received from telebirr account (receive / incoming)",
+    "example sms": "Dear Betelhem Fikru, You have received ETB 750.00 from telebirr account number 251911223344 Ref No:CFT8890012 on 07/06/2026 at 12:00 to your bank account '1000****5544'. Your account balance is ETB 5,600.00. Dashen Bank - Always one step ahead!",
+    "regex": "Dear\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*),?\\s+You\\s+have\\s+received\\s+(?<amount>[A-Za-z]{3}\\s?[\\d,]+\\.\\d{2})\\s+from\\s+telebirr\\s+account\\s+number\\s+(?<phone>\\d+)\\s+Ref\\s*No:?\\s*(?<reference>\\d+)\\s+on\\s+(?<date>[\\d/\\-]+)\\s+at\\s+(?<time>[\\d:]+(?:\\s?[APap][Mm])?)\\s+to\\s+your\\s+bank\\s+account\\s+['\"]?(?<account>[\\d*]+)['\"]?\\.?\\s*Your\\s+account\\s+balance\\s+is\\s+(?<balance>[A-Za-z]{3}\\s?[\\d,]+\\.\\d{2})",
+    "note": "Masked account digits and asterisks combined into a single `account` group; quotes around the account number are optional."
+  },
+  {
+    "title": "Telebirr — SMS OTP payment, CHUCHU SUPERMARKET (pay / outgoing)",
+    "example sms": "Dear Genet Wolde, You have paid ETB 450.00 by telebirr SMS OTP for CHUCHU SUPERMARKET, Chuchu Branch 02 on 06/07/2026 18:22:10. For attachment: https://mp.telebirr.et/recpt?ReceiptNo=123456ABC1DE_XYZ-ABC1_20260706182210",
+    "regex": "Dear\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*),?\\s+You\\s+have\\s+paid\\s+(?<amount>[A-Za-z]{3}\\s?[\\d,]+\\.\\d{2})\\s+by\\s+telebirr\\s+SMS\\s+OTP\\s+for\\s+CHUCHU\\s+SUPERMARKET,?\\s+Chuchu\\s+Branch\\s+(?<branch_num>\\d+)\\s+on\\s+(?<date>[\\d/]+)\\s+(?<time>[\\d:]+)\\.?\\s*For\\s+attachment:?\\s*(?<url>\\S+)"
+  },
+  {
+    "title": "Telebirr — QR Code payment, SMASH BURGERS (pay / outgoing)",
+    "example sms": "Dear Nardos Bekele, You have paid ETB 320.00 by telebirr QR Code for SMASH BURGERS, Main office on 05/07/2026 19:40. For attachment: https://mp.telebirr.et/recpt?ReceiptNo=987654XYZ1-12345-06 To download hulubeje app https://hbjee.download.et",
+    "regex": "Dear\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*),?\\s+You\\s+have\\s+paid\\s+(?<amount>[A-Za-z]{3}\\s?[\\d,]+\\.\\d{2})\\s+by\\s+telebirr\\s+QR\\s+Code\\s+for\\s+SMASH\\s+BURGERS,?\\s+Main\\s+office\\s+on\\s+(?<date>[\\d/]+)\\s+(?<time>[\\d:]+)\\.?\\s*For\\s+attachment:?\\s*(?<url>\\S+)(?:\\s+To\\s+download\\s+hulubeje\\s+app\\s+(?<url2>\\S+))?",
+    "note": "Second attachment URL is optional since not every sample includes the hulubeje link."
+  },
+  {
+    "title": "Telebirr — QR Code payment, YB GOOD TRADING PLC (pay / outgoing)",
+    "example sms": "Dear Dawit Alemayehu, You have paid ETB 275.50 by telebirr QR Code for YB GOOD TRADING PLC, Summit branch on 04/07/2026 15:12. For attachment: https://mp.telebirr.et/recpt?ReceiptNo=554433ABCD-2026-07",
+    "regex": "Dear\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*),?\\s+You\\s+have\\s+paid\\s+(?<amount>[A-Za-z]{3}\\s?[\\d,]+\\.\\d{2})\\s+by\\s+telebirr\\s+QR\\s+Code\\s+for\\s+YB\\s+GOOD\\s+TRADING\\s+PLC,?\\s+Summit\\s+branch\\s+on\\s+(?<date>[\\d/]+)\\s+(?<time>[\\d:]+)\\.?\\s*For\\s+attachment:?\\s*(?<url>\\S+)"
+  },
+  {
+    "title": "Ethio telecom — bill paid, no receipt link (pay / outgoing)",
+    "example sms": "Dear Meseret Alene, You have paid 300.00 Birr as of 2026-07-05 for telecom bill of Account Number 100234567. Your remaining outstanding amount is 1,200.00 Birr. Thank you, Ethio telecom.",
+    "regex": "Dear\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*),?\\s+You\\s+have\\s+paid\\s+(?<amount>[\\d,]+\\.\\d{2})\\s+Birr\\s+as\\s+of\\s+(?<date>[\\d\\-/]+)\\s+for\\s+telecom\\s+bill\\s+of\\s+Account\\s+Number\\s+(?<account>\\d+)\\.?\\s*Your\\s+remaining\\s+outstanding\\s+amount\\s+is\\s+(?<balance>[\\d,]+\\.\\d{2})\\s+Birr\\.?\\s*Thank\\s+you,?\\s+Ethio\\s+telecom\\.?"
+  },
+  {
+    "title": "Ethio telecom — bill paid, with receipt link (pay / outgoing)",
+    "example sms": "Dear Fitsum Getachew, You have paid 450.00 Birr as of 2026-07-04 for telecom bill of Account Number 100987654. Your remaining outstanding amount is 0.00 Birr. Your bill payment receipt link is https://ethiotelecom.et/receipt?id=778899&code=ABC123 You can download your receipt after 5 minutes. Thank you, Ethio telecom.",
+    "regex": "Dear\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*),?\\s+You\\s+have\\s+paid\\s+(?<amount>[\\d,]+\\.\\d{2})\\s+Birr\\s+as\\s+of\\s+(?<date>[\\d\\-/]+)\\s+for\\s+telecom\\s+bill\\s+of\\s+Account\\s+Number\\s+(?<account>\\d+)\\.?\\s*Your\\s+remaining\\s+outstanding\\s+amount\\s+is\\s+(?<balance>[\\d,]+\\.\\d{2})\\s+Birr\\.?\\s*Your\\s+bill\\s+payment\\s+receipt\\s+link\\s+is\\s+(?<url>\\S+)\\s+You\\s+can\\s+download\\s+your\\s+receipt\\s+after\\s+(?<minutes>\\d+)\\s+minutes\\.?\\s*Thank\\s+you,?\\s+Ethio\\s+telecom\\.?"
+  },
+  {
+    "title": "Bank — account debited with service charge & VAT (debit / outgoing)",
+    "example sms": "Dear Tigist Mulugeta your Account 1000****2233 has been debited with ETB250.00 . Service charge of ETB5.00 and VAT(15%) of ETB0.75 with a total of ETB255.75.",
+    "regex": "Dear\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*)\\s+your\\s+Account\\s+(?<account>[\\d*]+)\\s+has\\s+been\\s+debited\\s+with\\s+(?<amount>[A-Za-z]{3}\\s?[\\d,]+(?:\\.\\d{2})?)\\s*\\.?\\s*Service\\s+charge\\s+of\\s+(?<service_charge>[A-Za-z]{3}\\s?[\\d,]+(?:\\.\\d{2})?)\\s+and\\s+VAT\\s*\\(\\s*(?<vat_pct>\\d+)\\s*%\\s*\\)\\s+of\\s+(?<vat_amount>[A-Za-z]{3}\\s?[\\d,]+(?:\\.\\d{2})?)\\s+with\\s+a\\s+total\\s+of\\s+(?<total>[A-Za-z]{3}\\s?[\\d,]+(?:\\.\\d{2})?)\\.?"
+  },
+  {
+    "title": "EBIRR/Coopay — money sent (send / outgoing)",
+    "example sms": "[-EBIRR-Coopay-] With Ref No:88213311 ETB120.00 sent to mardiya Tuma Amano(251933445566) at 06/07/2026 09:14, Your balance is ETB980.00.",
+    "regex": "\\[-EBIRR-Coopay-\\]\\s+With\\s+Ref\\s*No:?\\s*(?<reference>\\d+)\\s+(?<amount>[A-Za-z]{3}\\s?[\\d,]+(?:\\.\\d{2})?)\\s+sent\\s+to\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*)\\s*\\(\\s*(?<phone>\\d+)\\s*\\)\\s+at\\s+(?<date>[\\d/]+)\\s+(?<time>[\\d:]+),?\\s*Your\\s+balance\\s+is\\s+(?<balance>[A-Za-z]{3}\\s?[\\d,]+(?:\\.\\d{2})?)\\.?",
+    "note": "Case-insensitive matching covers both '-Coopay-' and '-COOPay-' casing variants; also reused for the near-identical 'sent to SELAMAWIT BEKELE GASHE' template."
+  },
+  {
+    "title": "EBIRR/COOPay — money received (receive / incoming)",
+    "example sms": "[-EBIRR-COOPay-] Ref:77102234 Confirmed. ETB300.00 Received from SELAMAWIT BEKELE GASHE (251911998877),Date: 05/07/2026 16:02, your new A/C balance is ETB1580.00",
+    "regex": "\\[-EBIRR-Coopay-\\]\\s+Ref:?\\s*(?<reference>\\d+)\\s+Confirmed\\.?\\s*(?<amount>[A-Za-z]{3}\\s?[\\d,]+(?:\\.\\d{2})?)\\s+Received\\s+from\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*)\\s*\\(\\s*(?<phone>\\d+)\\s*\\),?\\s*Date:?\\s*(?<date>[\\d/]+)\\s+(?<time>[\\d:]+),?\\s*your\\s+new\\s+A/?C\\s+balance\\s+is\\s+(?<balance>[A-Za-z]{3}\\s?[\\d,]+(?:\\.\\d{2})?)",
+    "note": "Case-insensitive; also covers the alt-casing '-Coopay-' variant received-from-mardiya sample."
+  },
+  {
+    "title": "Telebirr — QR Code payment, ADDISANA FOOD PLC (pay / outgoing)",
+    "example sms": "Dear Aster Solomon, You have paid ETB 190.00 by telebirr QR Code for ADDISANA FOOD PLC, BISHOFTU on 03/07/2026 12:05. For attachment: https://mp.telebirr.et/recpt?ReceiptNo=112233CD-556-01 To download hulubeje app https://hbjee.download.et",
+    "regex": "Dear\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*),?\\s+You\\s+have\\s+paid\\s+(?<amount>[A-Za-z]{3}\\s?[\\d,]+\\.\\d{2})\\s+by\\s+telebirr\\s+QR\\s+Code\\s+for\\s+ADDISANA\\s+FOOD\\s+PLC,?\\s+BISHOFTU\\s+on\\s+(?<date>[\\d/]+)\\s+(?<time>[\\d:]+)\\.?\\s*For\\s+attachment:?\\s*(?<url>\\S+)(?:\\s+To\\s+download\\s+hulubeje\\s+app\\s+(?<url2>\\S+))?"
+  },
+  {
+    "title": "Telebirr — QR Code payment, lebu restaurant (pay / outgoing)",
+    "example sms": "Dear Mahlet Zewdu, You have paid ETB 260.00 by telebirr QR Code for BESRATEGEBRYEL SAHILU GETANEH, lebu restaurant on 02/07/2026 20:15. For attachment: https://mp.telebirr.et/recpt?ReceiptNo=889900XY-771-02 To download hulubeje app https://hbjee.download.et",
+    "regex": "Dear\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*),?\\s+You\\s+have\\s+paid\\s+(?<amount>[A-Za-z]{3}\\s?[\\d,]+\\.\\d{2})\\s+by\\s+telebirr\\s+QR\\s+Code\\s+for\\s+BESRATEGEBRYEL\\s+SAHILU\\s+GETANEH,?\\s+lebu\\s+restaurant\\s+on\\s+(?<date>[\\d/]+)\\s+(?<time>[\\d:]+)\\.?\\s*For\\s+attachment:?\\s*(?<url>\\S+)(?:\\s+To\\s+download\\s+hulubeje\\s+app\\s+(?<url2>\\S+))?"
+  },
+  {
+    "title": "Telebirr — QR Code payment, Michael Girma Coffee Processing (pay / outgoing)",
+    "example sms": "Dear Biniam Assefa, You have paid ETB 540.75 by telebirr QR Code for Michael Girma Coffee Processing, Atlas Branch on 01/07/2026 08:50. For attachment: https://mp.telebirr.et/recpt?ReceiptNo=334455EF-882-03 To download hulubeje app https://hbjee.download.et",
+    "regex": "Dear\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*),?\\s+You\\s+have\\s+paid\\s+(?<amount>[A-Za-z]{3}\\s?[\\d,]+\\.\\d{2})\\s+by\\s+telebirr\\s+QR\\s+Code\\s+for\\s+Michael\\s+Girma\\s+Coffee\\s+Processing,?\\s+Atlas\\s+Branch\\s+on\\s+(?<date>[\\d/]+)\\s+(?<time>[\\d:]+)\\.?\\s*For\\s+attachment:?\\s*(?<url>\\S+)(?:\\s+To\\s+download\\s+hulubeje\\s+app\\s+(?<url2>\\S+))?"
+  },
+  {
+    "title": "Telebirr — SMS OTP payment, Nehco Trading Plc (pay / outgoing)",
+    "example sms": "Dear Elias Tesema, You have paid ETB 620.00 by telebirr SMS OTP for Nehco Trading Plc, Main Branch on 30/06/2026 17:35. For attachment: https://mp.telebirr.et/recpt?ReceiptNo=112200GH-993-04 To download hulubeje app https://hbjee.download.et",
+    "regex": "Dear\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*),?\\s+You\\s+have\\s+paid\\s+(?<amount>[A-Za-z]{3}\\s?[\\d,]+\\.\\d{2})\\s+by\\s+telebirr\\s+SMS\\s+OTP\\s+for\\s+Nehco\\s+Trading\\s+Plc,?\\s+Main\\s+Branch\\s+on\\s+(?<date>[\\d/]+)\\s+(?<time>[\\d:]+)\\.?\\s*For\\s+attachment:?\\s*(?<url>\\S+)(?:\\s+To\\s+download\\s+hulubeje\\s+app\\s+(?<url2>\\S+))?"
+  },
+  {
+    "title": "EBIRR/COOPay — inbound interconnect wallet transfer (transfer / outgoing*)",
+    "example sms": "[-EBIRR-COOPay-] Transfer ID: 34567890, ETB500.00 received from Ayman Hasan Abdulahi(251944556677) via INTERCONNECT KAAFI MF WALLET, your balance is ETB2200.00 https://ebirr.et/r/34567890",
+    "regex": "\\[-EBIRR-Coopay-\\]\\s+Transfer\\s+ID:?\\s*(?<reference>\\d+),?\\s+(?<amount>[A-Za-z]{3}\\s?[\\d,]+(?:\\.\\d{2})?)\\s+received\\s+from\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*)\\s*\\(\\s*(?<phone>\\d+)\\s*\\)\\s+via\\s+INTERCONNECT\\s+KAAFI\\s+MF\\s+WALLET,?\\s+your\\s+balance\\s+is\\s+(?<balance>[A-Za-z]{3}\\s?[\\d,]+(?:\\.\\d{2})?)\\s*(?<url>\\S+)?",
+    "note": "Direction is stored as 'outgoing' upstream despite this being an inbound amount — verify against your business logic, not the regex."
+  },
+  {
+    "title": "EBIRR/Coopay — airtime top-up received (transfer / outgoing*)",
+    "example sms": "[-EBIRR-Coopay-] Transfer ID: 11223344, You have received airtime top-up of ETB50.00 from 251955667788",
+    "regex": "\\[-EBIRR-Coopay-\\]\\s+Transfer\\s+ID:?\\s*(?<reference>\\d+),?\\s+You\\s+have\\s+received\\s+airtime\\s+top-?up\\s+of\\s+(?<amount>[A-Za-z]{3}\\s?[\\d,]+(?:\\.\\d{2})?)\\s+from\\s+(?<phone>\\d+)"
+  },
+  {
+    "title": "Bank — account debited, truncated message (debit / outgoing)",
+    "example sms": "Dear Solomon Bekele your Account 1000****4455 has been debited with ETB60.00 . Service",
+    "regex": "Dear\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*)\\s+your\\s+Account\\s+(?<account>[\\d*]+)\\s+has\\s+been\\s+debited\\s+with\\s+(?<amount>[A-Za-z]{3}\\s?[\\d,]+(?:\\.\\d{2})?)\\s*\\.?\\s*Service\\b",
+    "note": "Message is truncated in source data; regex intentionally stops at 'Service' as an end-of-guaranteed-content marker."
+  },
+  {
+    "title": "Berhan Bank — account credited (credit / incoming)",
+    "example sms": "Dear Kidist Yohannes, A/C No. 100223344 has been credited ETB 900.00 on 2026-07-02. Reference is FT66123. Balance is ETB 5,200.00. 1234567 - Deposit Account Active Credit . Berhan Stress Free Banking",
+    "regex": "Dear\\s+(?<name>[A-Za-z]+(?:\\s[A-Za-z]+)*),?\\s+A/?C\\s*No\\.?\\s*(?<account>[A-Za-z0-9]+)\\s+has\\s+been\\s+credited\\s+(?<amount>[A-Za-z0-9\\s,.]+?)\\s+on\\s+(?<date>[\\w\\-/]+)\\.?\\s*Reference\\s+is\\s+(?<reference>[A-Za-z0-9]*)\\.?\\s*Balance\\s+is\\s+(?<balance>[A-Za-z0-9\\s,.]+?)\\.?\\s*(?<acct_num>\\d+)?\\s*-?\\s*Deposit\\s+Account\\s+Active\\s+Credit\\s*\\.?\\s*Berhan\\s+Stress\\s+Free\\s+Banking",
+    "note": "`reference` may legitimately be empty since the source sample had a literal blank placeholder there."
+  }
+]

--- a/app/test/fixtures/unmatched-with-regex.json
+++ b/app/test/fixtures/unmatched-with-regex.json
@@ -1,0 +1,23 @@
+[
+  {
+    "title": "Telebirr — Mela contract repayment (credit / incoming)",
+    "example sms": "Dear Bereket Alemu have repaid 350.00 ETB, for your Mela 15 days contract. Your current unpaid credit amount is 1,250.00 ETB. Thank you for using telebirr Ethio telecom",
+  },
+  {
+    "title": "M-PESA — received from Dashen Bank B2C (receive / incoming)",
+    "example sms": "Dear Hana Girma, you have received 2,500.00 Birr from DASHEN BANK SHARE COMPANY- B2C - EYOSIAS TAMIRAT ADINEW on 05/07/2026 at 10:15 AM. Transaction number is MPX9081726. Your current M-PESA balance is 3,750.50 Birr."
+  },
+  {
+    "title": "Telebirr — deposit to Saving Account (deposit / incoming)",
+    "example sms": "Dear Yared Mekonnen have successfully deposited ETB 500.00 to your Saving Account on 03/07/2026 09:20. Your telebirr transaction number is CFT7788112. Your current Saving balance is ETB 4,500.00 and Your current telebirr Account balance is ETB 220.00. Thank you for using telebirr Ethio telecom"
+  },
+  {
+    "title": "Telebirr — endekise credit transaction (credit / incoming)",
+    "example sms": "Dear Robel Haile transaction is successfully completed using endekise. You have used ETB 5.00 credit amount on this transaction. The service fee is ETB 1.50. Your outstanding amount is ETB 6.50 with due date of 2026-07-20 00:00. Your Contract number is 481029. Thank you for using telebirr Ethio telecom in partnership with Dashen Bank"
+  },
+  {
+    "title": "CBE/Michu — account credited, Temporary Deposit (credit / incoming)",
+    "example sms": "Dear Wondwosen Girma your Account 1000****7788 has been Credited with ETB 800.00 Ref: CBE9081726 ON 05-Jul-2026 14:30BY Temporary Deposit Customer Account. Your Current Balance is ETB 3,400.00. Get loans at your fingertips! Download Michu 2.0 here https://michu.cbe.com.et/app"
+  },
+
+]

--- a/app/test/helpers/sqlite_setup.dart
+++ b/app/test/helpers/sqlite_setup.dart
@@ -1,0 +1,52 @@
+import 'dart:ffi';
+import 'dart:io';
+import 'package:sqlite3/open.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+// Linux test helper for sqlite3 dynamic library loading.
+//
+// On Linux the sqlite3 package (transitive dep of sqflite_common_ffi) tries to
+// load libsqlite3.so by default, but many distros ship only libsqlite3.so.0
+// (no unversioned .so symlink).  In a Flutter test runner there is no
+// sqlite3_flutter_libs plugin bundled, so the default open path fails with:
+//   Failed to load dynamic library 'libsqlite3.so':
+//   cannot open shared object file: No such file or directory
+//
+// The fix: override the sqlite3 package's library-loader with a fallback that
+// tries libsqlite3.so first, then libsqlite3.so.0.
+//
+// ┌─ Important: sqflite_common_ffi spawns a background isolate ───────────┐
+// │ databaseFactoryFfi  uses Isolate.spawn() – the override set in the   │
+// │                     main isolate is NOT visible in the background     │
+// │                     isolate (each isolate has its own heap).          │
+// │                                                                       │
+// │ databaseFactoryFfiNoIsolate  runs DB ops on the main isolate – the   │
+// │                               override works correctly.              │
+// │                                                                       │
+// │ Always use databaseFactoryFfiNoIsolate in tests that open a database. │
+// └───────────────────────────────────────────────────────────────────────┘
+
+DynamicLibrary _openSqlite() {
+  try {
+    return DynamicLibrary.open('libsqlite3.so');
+  } on ArgumentError {
+    return DynamicLibrary.open('libsqlite3.so.0');
+  }
+}
+
+void setupSqlite() {
+  if (Platform.isLinux) {
+    open.overrideForAll(_openSqlite);
+  }
+}
+
+/// Returns an ffiInit callback for use with [createDatabaseFactoryFfi].
+///
+/// Pass this as the `ffiInit` argument when you must use the isolate-based
+/// factory (rare).  The callback runs inside the spawned isolate where it
+/// calls [open.overrideForAll] on the isolate's own heap.
+SqfliteFfiInit ffiInitForIsolate() => () {
+  if (Platform.isLinux) {
+    open.overrideForAll(_openSqlite);
+  }
+};

--- a/app/test/match_checker.dart
+++ b/app/test/match_checker.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+import 'dart:io';
+
+void main() {
+  final pJson = File('assets/sms_patterns.json').readAsStringSync();
+  final patterns = ((jsonDecode(pJson) as Map<String, dynamic>)['patterns'] as List)
+      .map((e) => {
+            'desc': e['description'],
+            'regex': e['regex'],
+            'hasAccount': e['hasAccount'],
+          })
+      .toList();
+
+  String fixJson(String raw) =>
+      raw.replaceAll(RegExp(r',\s*}'), '}').replaceAll(RegExp(r',\s*\]'), ']');
+
+  final all = <Map<String, dynamic>>[];
+  for (final f in ['test/fixtures/unmatched-with-regex.json', 'test/fixtures/unmatched-no-regex.json']) {
+    final raw = fixJson(File(f).readAsStringSync());
+    all.addAll((jsonDecode(raw) as List).cast<Map<String, dynamic>>());
+  }
+
+  int noMatch = 0;
+  for (final item in all) {
+    final body = item['example sms'] as String;
+    bool found = false;
+    for (final p in patterns) {
+      try {
+        final re = RegExp(p['regex'] as String, caseSensitive: false, multiLine: true, dotAll: true);
+        if (re.hasMatch(body)) {
+          print('MATCH: ${item['title']}');
+          print('   -> ${p['desc']} (hasAccount: ${p['hasAccount']})');
+          found = true;
+          break;
+        }
+      } catch (_) {}
+    }
+    if (!found) {
+      print('NO MATCH: ${item['title']}');
+      noMatch++;
+    }
+  }
+  print('\nTotal unmatched: ${all.length}, still no match: $noMatch');
+  exit(noMatch > 0 ? 1 : 0);
+}

--- a/app/test/parser1_extraction_integrity_test.dart
+++ b/app/test/parser1_extraction_integrity_test.dart
@@ -1,0 +1,208 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:totals/models/sms_pattern.dart';
+import 'package:totals/utils/pattern_parser.dart';
+
+int _countCaptureGroups(String regex) {
+  int count = 0;
+  int i = 0;
+  bool inClass = false;
+  while (i < regex.length) {
+    if (regex[i] == '\\') {
+      i += 2;
+      continue;
+    }
+    if (regex[i] == '[') {
+      inClass = true;
+      i++;
+      continue;
+    }
+    if (regex[i] == ']') {
+      inClass = false;
+      i++;
+      continue;
+    }
+    if (!inClass && regex[i] == '(') {
+      if (i + 2 < regex.length && regex[i + 1] == '?' && regex[i + 2] == '<') {
+        count++;
+        final close = regex.indexOf('>', i + 3);
+        i = close + 1;
+        continue;
+      }
+      if (i + 1 < regex.length && regex[i + 1] == '?') {
+        i += 3;
+        continue;
+      }
+      count++;
+    }
+    i++;
+  }
+  return count;
+}
+
+List<SmsPattern> _loadPatterns() {
+  final json = jsonDecode(File('assets/sms_patterns.json').readAsStringSync());
+  return (json['patterns'] as List)
+      .map((e) => SmsPattern.fromJson(e as Map<String, dynamic>))
+      .toList();
+}
+
+List<String> _loadSampleBodies() {
+  String fixJson(String raw) =>
+      raw.replaceAll(RegExp(r',\s*}'), '}').replaceAll(RegExp(r',\s*\]'), ']');
+
+  final withRegex = jsonDecode(fixJson(
+          File('test/fixtures/unmatched-with-regex.json').readAsStringSync()))
+      as List;
+  final noRegex = jsonDecode(fixJson(
+          File('test/fixtures/unmatched-no-regex.json').readAsStringSync()))
+      as List;
+  return [
+    ...withRegex.map((e) => e['example sms'] as String),
+    ...noRegex.map((e) => e['example sms'] as String),
+  ];
+}
+
+void main() {
+  setUpAll(() {
+    // PatternParser account masking may touch sqflite; keep extraction quiet.
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  group('fieldMapping / regex-group consistency', () {
+    test('mapping index never exceeds the actual capture-group count', () {
+      final patterns = _loadPatterns();
+      final violations = <String>[];
+
+      for (final pattern in patterns) {
+        if (pattern.fieldMapping == null) continue;
+        final groupCount = _countCaptureGroups(pattern.regex);
+        for (final entry in pattern.fieldMapping!.entries) {
+          final index = int.tryParse(entry.value);
+          if (index == null) {
+            violations.add('${pattern.description}: mapping value for '
+                '"${entry.key}" is not a valid integer: "${entry.value}"');
+            continue;
+          }
+          if (index < 0 || index > groupCount) {
+            violations.add('${pattern.description}: mapping key '
+                '"${entry.key}" -> group $index, but the regex only has '
+                '$groupCount capture groups');
+          }
+        }
+      }
+
+      expect(violations, isEmpty, reason: violations.join('\n'));
+    });
+
+    test(
+        'extraction snapshot — fixture bodies that match still extract amount',
+        () async {
+      final patterns = _loadPatterns();
+      final bodies = _loadSampleBodies();
+      final messageDate = DateTime(2026, 7, 12);
+      var matched = 0;
+
+      for (final body in bodies) {
+        final result = await PatternParser.extractTransactionDetails(
+          body,
+          '',
+          messageDate,
+          patterns,
+        );
+        if (result == null) continue;
+        matched++;
+        expect(result['amount'], isNotNull,
+            reason: 'matched body must yield an amount:\n$body');
+      }
+
+      expect(matched, greaterThan(0),
+          reason: 'fixture corpus should produce at least one extraction');
+    });
+  });
+
+  group('fee computation edge cases', () {
+    test(
+        'combined totalFee capture takes precedence over serviceCharge+vat '
+        'derivation, never sums with it', () async {
+      final pattern = SmsPattern(
+        bankId: 99,
+        senderId: 'SYN',
+        regex: r'Debit (?<amount>[\d.]+) SC (?<serviceCharge>[\d.]+) '
+            r'VAT (?<vat>[\d.]+) Fees (?<totalFees>[\d.]+)',
+        type: 'DEBIT',
+        description: 'synthetic combined totalFees',
+        fieldMapping: const {
+          'amount': '1',
+          'serviceCharge': '2',
+          'vat': '3',
+          'totalFees': '4',
+        },
+      );
+      final result = await PatternParser.extractTransactionDetails(
+        'Debit 100.00 SC 5.00 VAT 2.00 Fees 9.00',
+        '',
+        DateTime(2026, 7, 12),
+        [pattern],
+      );
+      expect(result, isNotNull);
+      expect(result!['totalFee'], 9.0,
+          reason: 'captured totalFees must win over serviceCharge+vat (7.0)');
+    });
+
+    test('missing vat with present serviceCharge does not silently zero '
+        'or invent totalFee', () async {
+      final pattern = SmsPattern(
+        bankId: 99,
+        senderId: 'SYN',
+        regex: r'Debit (?<amount>[\d.]+) SC (?<serviceCharge>[\d.]+)',
+        type: 'DEBIT',
+        description: 'synthetic serviceCharge only',
+        fieldMapping: const {
+          'amount': '1',
+          'serviceCharge': '2',
+        },
+      );
+      final result = await PatternParser.extractTransactionDetails(
+        'Debit 100.00 SC 5.00',
+        '',
+        DateTime(2026, 7, 12),
+        [pattern],
+      );
+      expect(result, isNotNull);
+      expect(result!.containsKey('totalFee'), isFalse,
+          reason: 'without vat, totalFee must not be derived as 0 or partial');
+    });
+  });
+
+  group('regex safety across the corpus', () {
+    test('no pattern regex exhibits catastrophic backtracking on '
+        'adversarial input', () {
+      final patterns = _loadPatterns();
+      final adversarialInput = List.filled(200, '1234567890').join();
+
+      for (final pattern in patterns) {
+        RegExp regex;
+        try {
+          regex = RegExp(pattern.regex,
+              caseSensitive: false, multiLine: true, dotAll: true);
+        } catch (_) {
+          continue;
+        }
+        final stopwatch = Stopwatch()..start();
+        try {
+          regex.firstMatch(adversarialInput);
+        } catch (_) {}
+        stopwatch.stop();
+        expect(stopwatch.elapsedMilliseconds, lessThan(1000),
+            reason: '${pattern.description}: took '
+                '${stopwatch.elapsedMilliseconds}ms against a 2000-char '
+                'adversarial string — possible catastrophic backtracking');
+      }
+    });
+  });
+}

--- a/app/test/repair_core_v28_column_ensures_test.dart
+++ b/app/test/repair_core_v28_column_ensures_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:totals/database/database_helper.dart';
+import 'helpers/sqlite_setup.dart';
+
+void main() {
+  setUpAll(() {
+    setupSqlite();
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfiNoIsolate;
+  });
+
+  Future<Database> openPreFixDatabase() async {
+    final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+    await db.execute('''
+      CREATE TABLE transactions (
+        id INTEGER PRIMARY KEY,
+        amount REAL,
+        reference TEXT
+      )
+    ''');
+    await db.execute('''
+      CREATE TABLE sms_patterns (
+        id INTEGER PRIMARY KEY,
+        bankId INTEGER,
+        regex TEXT
+      )
+    ''');
+    return db;
+  }
+
+  Future<Set<String>> columnNames(Database db, String table) async {
+    final info = await db.rawQuery('PRAGMA table_info($table)');
+    return info.map((c) => c['name'] as String).toSet();
+  }
+
+  Future<String?> columnType(Database db, String table, String column) async {
+    final info = await db.rawQuery('PRAGMA table_info($table)');
+    final match = info.where((c) => c['name'] == column);
+    return match.isEmpty ? null : match.first['type'] as String?;
+  }
+
+  test('adds totalFee, hasFees, and mapping when missing', () async {
+    final db = await openPreFixDatabase();
+
+    expect(await columnNames(db, 'transactions'), isNot(contains('totalFee')));
+    expect(await columnNames(db, 'sms_patterns'), isNot(contains('hasFees')));
+    expect(await columnNames(db, 'sms_patterns'), isNot(contains('mapping')));
+
+    await DatabaseHelper.instance.repairCoreV28(db);
+
+    expect(await columnNames(db, 'transactions'), contains('totalFee'));
+    expect(await columnNames(db, 'sms_patterns'), contains('hasFees'));
+    expect(await columnNames(db, 'sms_patterns'), contains('mapping'));
+
+    expect(await columnType(db, 'transactions', 'totalFee'), 'REAL');
+    expect(await columnType(db, 'sms_patterns', 'hasFees'), 'INTEGER');
+    expect(await columnType(db, 'sms_patterns', 'mapping'), 'TEXT');
+
+    await db.close();
+  });
+
+  test('running it twice does not error or duplicate columns', () async {
+    final db = await openPreFixDatabase();
+
+    await DatabaseHelper.instance.repairCoreV28(db);
+    await DatabaseHelper.instance.repairCoreV28(db);
+
+    final txColumns = await db.rawQuery('PRAGMA table_info(transactions)');
+    expect(txColumns.where((c) => c['name'] == 'totalFee').length, 1);
+
+    final patternColumns = await db.rawQuery('PRAGMA table_info(sms_patterns)');
+    expect(patternColumns.where((c) => c['name'] == 'hasFees').length, 1);
+    expect(patternColumns.where((c) => c['name'] == 'mapping').length, 1);
+
+    await db.close();
+  });
+
+  test('running it against a database that already has the columns is a no-op',
+      () async {
+    final db = await openPreFixDatabase();
+    await db.execute('ALTER TABLE transactions ADD COLUMN totalFee REAL');
+    await db.execute('ALTER TABLE sms_patterns ADD COLUMN hasFees INTEGER');
+    await db.execute('ALTER TABLE sms_patterns ADD COLUMN mapping TEXT');
+
+    await DatabaseHelper.instance.repairCoreV28(db);
+
+    final txColumns = await db.rawQuery('PRAGMA table_info(transactions)');
+    expect(txColumns.where((c) => c['name'] == 'totalFee').length, 1);
+
+    final patternColumns = await db.rawQuery('PRAGMA table_info(sms_patterns)');
+    expect(patternColumns.where((c) => c['name'] == 'hasFees').length, 1);
+    expect(patternColumns.where((c) => c['name'] == 'mapping').length, 1);
+
+    await db.close();
+  });
+}

--- a/app/test/residual_gaps_from_json_fees_test.dart
+++ b/app/test/residual_gaps_from_json_fees_test.dart
@@ -1,0 +1,66 @@
+// Residual gap B1 — optional fee fields must stay null when absent in JSON,
+// not silently become 0.0.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:totals/models/transaction.dart';
+
+void main() {
+  group('B1: Transaction.fromJson optional fees', () {
+    test('missing serviceCharge/vat/totalFee stay null', () {
+      final tx = Transaction.fromJson({
+        'amount': 100,
+        'reference': 'REF-B1',
+      });
+
+      expect(tx.amount, 100);
+      expect(tx.serviceCharge, isNull);
+      expect(tx.vat, isNull);
+      expect(tx.totalFee, isNull);
+    });
+
+    test('explicit null fee keys stay null', () {
+      final tx = Transaction.fromJson({
+        'amount': 100,
+        'reference': 'REF-B1b',
+        'serviceCharge': null,
+        'vat': null,
+        'totalFee': null,
+      });
+
+      expect(tx.serviceCharge, isNull);
+      expect(tx.vat, isNull);
+      expect(tx.totalFee, isNull);
+    });
+
+    test('present fee values parse correctly including zero', () {
+      final tx = Transaction.fromJson({
+        'amount': 100,
+        'reference': 'REF-B1c',
+        'serviceCharge': 1.5,
+        'vat': 0.0,
+        'totalFee': '2.75',
+      });
+
+      expect(tx.serviceCharge, closeTo(1.5, 0.001));
+      expect(tx.vat, 0.0);
+      expect(tx.totalFee, closeTo(2.75, 0.001));
+    });
+
+    test('toJson omits null fees and includes present ones', () {
+      final withFees = Transaction.fromJson({
+        'amount': 10,
+        'reference': 'R',
+        'totalFee': 1.0,
+      });
+      final withoutFees = Transaction.fromJson({
+        'amount': 10,
+        'reference': 'R',
+      });
+
+      expect(withFees.toJson().containsKey('totalFee'), isTrue);
+      expect(withoutFees.toJson().containsKey('totalFee'), isFalse);
+      expect(withoutFees.toJson().containsKey('serviceCharge'), isFalse);
+      expect(withoutFees.toJson().containsKey('vat'), isFalse);
+    });
+  });
+}

--- a/app/test/residual_gaps_reparse_total_fee_test.dart
+++ b/app/test/residual_gaps_reparse_total_fee_test.dart
@@ -1,0 +1,123 @@
+// Residual gaps A1/A2/A4 — reparse merge must persist totalFee when that is
+// the only field filled from a reparsed candidate.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:totals/models/transaction.dart';
+import 'package:totals/services/account_transaction_reparse_service.dart';
+
+void main() {
+  late AccountTransactionReparseService service;
+
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+  });
+
+  setUp(() {
+    service = AccountTransactionReparseService();
+  });
+
+  group('A1: mergeParsedFields totalFee-only fill', () {
+    test('returns updated tx when reparse only supplies totalFee', () {
+      final existing = Transaction(
+        amount: 100,
+        reference: 'REF-A1',
+        creditor: 'Shop',
+        type: 'DEBIT',
+        time: '2026-01-15T10:00:00.000',
+      );
+      final reparsed = Transaction(
+        amount: 100,
+        reference: 'REF-A1',
+        creditor: 'Shop',
+        type: 'DEBIT',
+        time: '2026-01-15T10:00:00.000',
+        totalFee: 5.5,
+      );
+
+      final merged = service.mergeParsedFieldsForTest(existing, reparsed);
+
+      expect(merged, isNotNull,
+          reason: 'totalFee-only improvement must not be treated as no-op');
+      expect(merged!.totalFee, closeTo(5.5, 0.001));
+      expect(merged.reference, 'REF-A1');
+      expect(merged.creditor, 'Shop');
+    });
+
+    test('returns null when totalFee already present and equal', () {
+      final existing = Transaction(
+        amount: 100,
+        reference: 'REF-A1b',
+        totalFee: 5.5,
+      );
+      final reparsed = Transaction(
+        amount: 100,
+        reference: 'REF-A1b',
+        totalFee: 9.9, // existing wins via _pickAmount
+      );
+
+      final merged = service.mergeParsedFieldsForTest(existing, reparsed);
+
+      expect(merged, isNull,
+          reason: 'meaningful existing totalFee is kept; no other fields change');
+    });
+
+    test('preserves existing totalFee when reparsed omits it', () {
+      final existing = Transaction(
+        amount: 100,
+        reference: 'REF-A1c',
+        totalFee: 3.25,
+        receiver: null,
+      );
+      final reparsed = Transaction(
+        amount: 100,
+        reference: 'REF-A1c',
+        receiver: 'New Merchant',
+      );
+
+      final merged = service.mergeParsedFieldsForTest(existing, reparsed);
+
+      expect(merged, isNotNull);
+      expect(merged!.totalFee, closeTo(3.25, 0.001));
+      expect(merged.receiver, 'New Merchant');
+    });
+  });
+
+  group('A2: mergeExistingTransactionFields totalFee pick', () {
+    test('takes candidate totalFee when current has none', () {
+      final current = Transaction(
+        amount: 50,
+        reference: 'REF-A2',
+        creditor: 'A',
+      );
+      final candidate = Transaction(
+        amount: 50,
+        reference: 'REF-A2',
+        creditor: 'A',
+        totalFee: 2.0,
+      );
+
+      final merged =
+          service.mergeExistingTransactionFieldsForTest(current, candidate);
+
+      expect(merged.totalFee, closeTo(2.0, 0.001));
+    });
+
+    test('keeps current totalFee when already meaningful', () {
+      final current = Transaction(
+        amount: 50,
+        reference: 'REF-A2b',
+        totalFee: 4.0,
+      );
+      final candidate = Transaction(
+        amount: 50,
+        reference: 'REF-A2b',
+        totalFee: 9.0,
+      );
+
+      final merged =
+          service.mergeExistingTransactionFieldsForTest(current, candidate);
+
+      expect(merged.totalFee, closeTo(4.0, 0.001));
+    });
+  });
+}

--- a/app/test/utils/compose_date_time_test.dart
+++ b/app/test/utils/compose_date_time_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:totals/utils/pattern_parser.dart';
+
+void main() {
+  final messageDate = DateTime(2026, 7, 12);
+
+  group('boundary cases — should already be correct', () {
+    test('12h midnight: "12:00 AM" -> hour 0', () {
+      final r = PatternParser.composeDateTime(messageDate, '12:00 AM');
+      expect(DateTime.parse(r!).hour, 0);
+    });
+
+    test('12h noon: "12:00 PM" -> hour 12', () {
+      final r = PatternParser.composeDateTime(messageDate, '12:00 PM');
+      expect(DateTime.parse(r!).hour, 12);
+    });
+
+    test('12h with seconds: "2:45:30 PM" -> 14:45:30', () {
+      final r = PatternParser.composeDateTime(messageDate, '2:45:30 PM');
+      final dt = DateTime.parse(r!);
+      expect(dt.hour, 14);
+      expect(dt.minute, 45);
+      expect(dt.second, 30);
+    });
+
+    test('24h with seconds: "08:00:00" -> hour 8', () {
+      final r = PatternParser.composeDateTime(messageDate, '08:00:00');
+      expect(DateTime.parse(r!).hour, 8);
+    });
+
+    test('24h zero hour: "00:15" -> hour 0', () {
+      final r = PatternParser.composeDateTime(messageDate, '00:15');
+      expect(DateTime.parse(r!).hour, 0);
+    });
+
+    test('lowercase am/pm: "2:45pm" -> hour 14', () {
+      final r = PatternParser.composeDateTime(messageDate, '2:45pm');
+      expect(DateTime.parse(r!).hour, 14);
+    });
+  });
+
+  group('out-of-range input — requires the bounds-check patch to pass', () {
+    test('12h hour > 12 with PM suffix does not roll into next day', () {
+      final r = PatternParser.composeDateTime(messageDate, '14:45 PM');
+      expect(r, isNull);
+    });
+
+    test('minute > 59 does not roll into the next hour', () {
+      final r = PatternParser.composeDateTime(messageDate, '2:99 PM');
+      expect(r, isNull);
+    });
+
+    test('24h hour > 23 does not roll into following days', () {
+      final r = PatternParser.composeDateTime(messageDate, '99:15');
+      expect(r, isNull);
+    });
+  });
+
+  group('24h unpadded hour — widened to \d{1,2}, now composes', () {
+    test('"9:15" -> hour 9', () {
+      final r = PatternParser.composeDateTime(messageDate, '9:15');
+      final dt = DateTime.parse(r!);
+      expect(dt.hour, 9);
+      expect(dt.minute, 15);
+    });
+  });
+
+  group('malformed input — safe fallthrough, no throw', () {
+    test('trailing unit text: "14:30 hrs"', () {
+      final r = PatternParser.composeDateTime(messageDate, '14:30 hrs');
+      expect(r, isNull);
+    });
+
+    test('empty fragment', () {
+      final r = PatternParser.composeDateTime(messageDate, '   ');
+      expect(r, isNull);
+    });
+
+    test('dot separator instead of colon: "2.45 PM"', () {
+      final r = PatternParser.composeDateTime(messageDate, '2.45 PM');
+      expect(r, isNull);
+    });
+  });
+
+  group('pattern corpus regression — fill in the two TODOs', () {
+    final patterns = <dynamic>[];
+
+    for (final pattern in patterns) {
+      final hasTimeGroup = true;
+      if (!hasTimeGroup) continue;
+
+      test('${pattern.toString()}: time composes to valid ISO-8601', () async {
+        final result = await PatternParser.extractTransactionDetails(
+          '',    // TODO: plug in a realistic sample SMS body for this pattern
+          '',    // TODO: plug in the matching sender address
+          messageDate,
+          [],   // TODO: plug in the real 116-pattern list
+        );
+        expect(result?['time'], isNotNull,
+            reason: 'time group present but composition failed');
+        expect(DateTime.tryParse(result!['time'] as String), isNotNull,
+            reason: 'composed time is not valid ISO-8601');
+      });
+    }
+  });
+}


### PR DESCRIPTION
### Changes

- **pattern_parser**: added fieldMapping support, `_groupValue`/`_hasGroup` helpers, totalDebit/totalFee split, stronger synthesized reference dedup keys
- **DB v28→v29**: added hasFees/mapping to `sms_patterns`, totalFee to `transactions`, with migration path
- **SmsPattern model**: added hasFees, fieldMapping fields
- **Transaction model**: added totalFee field
- **EnrichmentPipeline**: abstract `TransactionEnricher` interface with chain-of-responsibility pipeline; shell registration in `SmsService` (enrichers register from their own PRs)
- **sms_service**: calls enrichment pipeline after `Transaction.fromJson`; background SMS registration
- **sms_config_service**: persists hasFees/mapping columns with JSON round-trip
- **account_balance_resolver**: derives balance from amount+totalFee when currentBalance is null
- **transaction_repository**: persists/reads totalFee
- **copyWith fixes**: `TransactionDetailsSheet` and `TransactionProvider` use `copyWith()` instead of field-by-field constructors (which silently dropped totalFee)
- **Reparse enrichment fix**: `account_transaction_reparse_service` now calls `enrichmentPipeline.enrich()` before saving

### Residual gaps fixed in this branch
- A1-A4: totalFee parity in reparse merge methods + `_mergeParsedFields` converted to `copyWith`
- B1: `Transaction.fromJson` optional fees (serviceCharge, vat, totalFee) return `null` instead of `0.0` when absent

### Notes
- Replaces old PR #71 (which was broken — imported MerchantNormalizer/CategorizerEnricher that didn't exist in its tree)
- PR 1 of 5 in a stacked chain. Merge order: p1 → p2 → p3 → p4 → p5.